### PR TITLE
Fix weird bool behavior

### DIFF
--- a/idasen_ha/__init__.py
+++ b/idasen_ha/__init__.py
@@ -122,4 +122,8 @@ class Desk:
     @property
     def is_connected(self) -> bool:
         """True if the bluetooth connection is currently established."""
-        return self._idasen_desk is not None and self._idasen_desk.is_connected
+        if self._idasen_desk is None:
+            return False
+        if not self._idasen_desk.is_connected:
+            return False
+        return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "idasen-ha"
-version = "1.2"
+version = "1.3"
 authors = [{name = "Abílio Costa", email = "amfcalt@gmail.com"}]
 description = "Home Assistant helper lib for the IKEA Idasen Desk integration"
 classifiers = [


### PR DESCRIPTION
For some reason `self._idasen_desk.is_connected` is `True`
but `self._idasen_desk.is_connected == True` is `False`.
Returning `is_connected` directly was propagating that weird behavior
to upper layers.
