### PR TITLE
Automatically keep connection state

### DIFF
--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable
 import logging
 from typing import Callable
 
+from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
 from idasen import IdasenDesk
 
@@ -17,26 +18,43 @@ class ConnectionManager:
     """Handles connecting to the desk. Optionally keeps retrying to connect until it succeeds."""
 
     def __init__(
-        self, desk: IdasenDesk, connect_callback: Callable[[], Awaitable[None]]
+        self,
+        ble_device: BLEDevice,
+        connect_callback: Callable[[], Awaitable[None]],
+        disconnect_callback: Callable[[], None],
     ):
         """Init ConnectionManager."""
-        self._idasen_desk = desk
-        self._connect_callback = connect_callback
-
+        self._keep_connected: bool = False
         self._connecting: bool = False
         self._retry_pending: bool = False
-        self._retry: bool = False
 
-    async def connect(self, retry: bool = True) -> None:
+        self._idasen_desk: IdasenDesk = self._create_idasen_desk(ble_device)
+
+        self._connect_callback = connect_callback
+        self._disconnect_callback = disconnect_callback
+
+    @property
+    def idasen_desk(self) -> IdasenDesk:
+        """The IdasenDesk instance."""
+        return self._idasen_desk
+
+    async def connect(self, retry: bool) -> None:
         """Perform the bluetooth connection to the desk."""
-        self._retry = retry
-        await self._connect(retry=retry)
+        self._keep_connected = True
+        await self._connect(retry)
 
     async def disconnect(self):
         """Stop the connection manager retry task."""
-        self._retry = False
+        self._keep_connected = False
         if self._idasen_desk.is_connected:
             await self._idasen_desk.disconnect()
+
+    def _create_idasen_desk(self, ble_device: BLEDevice) -> IdasenDesk:
+        return IdasenDesk(
+            ble_device,
+            exit_on_fail=False,
+            disconnected_callback=lambda bledevice: self._handle_disconnect(),
+        )
 
     async def _connect(self, retry: bool) -> None:
         if self._connecting:
@@ -49,7 +67,7 @@ class ConnectionManager:
                 _LOGGER.info("Connecting...")
                 await self._idasen_desk.connect()
             except (TimeoutError, BleakError) as ex:
-                _LOGGER.warning("Connect failed")
+                _LOGGER.exception("Connect failed")
                 if retry:
                     self._schedule_reconnect()
                     return
@@ -65,7 +83,7 @@ class ConnectionManager:
                     raise AuthFailedError() from ex
                 raise ex
             except Exception as ex:
-                _LOGGER.warning("Pair failed")
+                _LOGGER.exception("Pair failed")
                 await self._idasen_desk.disconnect()
                 if retry:
                     self._schedule_reconnect()
@@ -73,32 +91,56 @@ class ConnectionManager:
                 else:
                     raise ex
 
-            _LOGGER.info("Connected!")
-            self._retry = False
-            await self._connect_callback()
+            await self._handle_connect()
         finally:
             self._connecting = False
 
     def _schedule_reconnect(self):
         RECONNECT_INTERVAL_SEC = 30
-        _LOGGER.info("Will try to connect in %ds", RECONNECT_INTERVAL_SEC)
+        _LOGGER.info("Will try to reconnect in %ds", RECONNECT_INTERVAL_SEC)
 
         if self._retry_pending:
             _LOGGER.warning("There is already a reconnect task pending")
             return
+        self._retry_pending = True
 
         async def _reconnect():
-            self._retry_pending = True
             await asyncio.sleep(RECONNECT_INTERVAL_SEC)
             self._retry_pending = False
 
-            if self._retry is False:
+            if not self._keep_connected:
                 _LOGGER.debug(
-                    "Retrying is disalbed (this could be on an older instance for an older BLEDevice)"
+                    "Reconnect aborted since it should not be connected"
+                    "(this could be on an older instance for an older BLEDevice)"
                 )
                 return
 
-            _LOGGER.debug("Retrying to connect now")
-            await self._connect(retry=True)
+            if self.idasen_desk.is_connected:
+                _LOGGER.debug("Already connected")
+                return
+
+            _LOGGER.debug("Reconnecting now")
+            await self._connect(True)
 
         asyncio.get_event_loop().create_task(_reconnect())
+
+    async def _handle_connect(self) -> None:
+        _LOGGER.debug("Connected")
+        await self._connect_callback()
+        if not self._keep_connected:
+            _LOGGER.info("Disconnecting since it should not be connected")
+            asyncio.get_event_loop().create_task(self.disconnect())
+
+    def _handle_disconnect(self) -> None:
+        """Handle bluetooth disconnection."""
+        _LOGGER.debug("Disconnected")
+        if self._connecting:
+            _LOGGER.debug(
+                "Disconnected during connection process. No callback triggered."
+            )
+            return
+
+        self._disconnect_callback()
+        if self._keep_connected and not self._retry_pending:
+            _LOGGER.info("Reconnecting since it should not be disconnected")
+            asyncio.get_event_loop().create_task(self.connect(True))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@
 from bleak.backends.device import BLEDevice
 from idasen import IdasenDesk
 
-FAKE_BLE_DEVICE = BLEDevice("AA:BB:CC:DD:EE:FF", None, None, 0)
+FAKE_BLE_DEVICE = BLEDevice("AA:BB:CC:DD:EE:FF", None, {"path": ""}, 0)
 
 
 def height_percent_to_meters(percent: float):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,9 @@ import pytest
 async def mock_idasen_desk():
     """Test height monitoring."""
 
-    with mock.patch("idasen_ha.IdasenDesk", autospec=True) as patched_idasen_desk:
+    with mock.patch(
+        "idasen_ha.connection_manager.IdasenDesk", autospec=True
+    ) as patched_idasen_desk:
         patched_idasen_desk.MIN_HEIGHT = IdasenDesk.MIN_HEIGHT
         patched_idasen_desk.MAX_HEIGHT = IdasenDesk.MAX_HEIGHT
 


### PR DESCRIPTION
This moves the logic to keep the device connected when the connection
drops (and vice-versa) from HA to this lib.
