### PR TITLE
Retry on pair() exceptions

### DIFF
--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -71,14 +71,17 @@ class ConnectionManager:
                 if retry:
                     self._schedule_reconnect()
                     return
-                else:
-                    raise ex
+                raise ex
 
             try:
                 _LOGGER.info("Pairing...")
                 await self._idasen_desk.pair()
             except BleakDBusError as ex:
+                _LOGGER.exception("Pair failed")
                 await self._idasen_desk.disconnect()
+                if retry:
+                    self._schedule_reconnect()
+                    return
                 if ex.dbus_error == "org.bluez.Error.AuthenticationFailed":
                     raise AuthFailedError() from ex
                 raise ex
@@ -88,8 +91,7 @@ class ConnectionManager:
                 if retry:
                     self._schedule_reconnect()
                     return
-                else:
-                    raise ex
+                raise ex
 
             await self._handle_connect()
         finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "idasen-ha"
-version = "2.6.1"
+version = "2.6.2"
 authors = [{name = "Abílio Costa", email = "amfcalt@gmail.com"}]
 description = "Home Assistant helper lib for the IKEA Idasen Desk integration"
 classifiers = [

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -174,7 +174,15 @@ async def test_connect_exception_retry_with_disconnect(
 
 
 @mock.patch("idasen_ha.connection_manager.asyncio.sleep")
-@pytest.mark.parametrize("exception", [TimeoutError(), BleakError()])
+@pytest.mark.parametrize(
+    "exception",
+    [
+        TimeoutError(),
+        BleakError(),
+        BleakDBusError("", []),
+        BleakDBusError("org.bluez.Error.AuthenticationFailed", []),
+    ],
+)
 @pytest.mark.parametrize("fail_call_name", ["connect", "pair"])
 async def test_connect_exception_retry_success(
     sleep_mock,


### PR DESCRIPTION
Once in a while the desk replies with an auth error, but triggering a
connect again will connect just fine, so the retry logic should also
apply to pair() failures.
