### PR TITLE
Prevent reconnect when desk is already connected

### DIFF
--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -57,9 +57,14 @@ class ConnectionManager:
         )
 
     async def _connect(self, retry: bool) -> None:
-        if self._connecting:
-            _LOGGER.info("Connection already in progress.")
+        if self._idasen_desk.is_connected:
+            _LOGGER.debug("Desk already connected, skipping connect")
             return
+    
+        if self._connecting:
+            _LOGGER.debug("Connection already in progress")
+            return
+
 
         self._connecting = True
         try:

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -60,11 +60,10 @@ class ConnectionManager:
         if self._idasen_desk.is_connected:
             _LOGGER.debug("Desk already connected, skipping connect")
             return
-    
+
         if self._connecting:
             _LOGGER.debug("Connection already in progress")
             return
-
 
         self._connecting = True
         try:

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -32,6 +32,19 @@ async def test_connect_disconnect(mock_idasen_desk: MagicMock):
     assert update_callback.call_count == 2
 
 
+async def test_connect_skipped_when_already_connected(mock_idasen_desk: MagicMock):
+    """Test that connect is skipped when the desk is already connected."""
+    update_callback = Mock()
+    desk = Desk(update_callback, False)
+
+    mock_idasen_desk.is_connected = True
+
+    await desk.connect(FAKE_BLE_DEVICE)
+    mock_idasen_desk.connect.assert_not_awaited()
+    mock_idasen_desk.pair.assert_not_called()
+    assert update_callback.call_count == 0
+
+
 async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMock):
     """Test connect being called again with the same BLEDevice, while still connecting."""
     update_callback = Mock()


### PR DESCRIPTION
This fixes the root cause of the “Notifications are already enabled” BleakError.

The ConnectionManager could call `_connect()` while the desk was already connected, causing BLE notifications to be registered multiple times. This resulted in Bleak raising an error and Home Assistant logging repeated task exceptions.

This change adds an early guard using `idasen_desk.is_connected` to prevent reconnect attempts when the connection is already active.

This avoids duplicate connect/pair/notify calls and fixes the BLE race condition instead of suppressing errors.

Tested with IKEA Idasen desks via ESP32 Bluetooth Proxy and native BLE.