### PR TITLE
fix: bleak retry connector warning

### DIFF
--- a/idasen_ha/__init__.py
+++ b/idasen_ha/__init__.py
@@ -7,6 +7,7 @@ import logging
 from typing import Callable
 
 from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
 from idasen import IdasenDesk
 
 from .connection_manager import ConnectionManager
@@ -67,7 +68,11 @@ class Desk:
             return
 
         if self._idasen_desk.is_moving:
-            await self._idasen_desk.stop()
+            try:
+                await self._idasen_desk.stop()
+            except (BleakError, TimeoutError):
+                _LOGGER.warning("Failed to stop desk before moving", exc_info=True)
+                return
             # Let it settle before requesting a new move
             await asyncio.sleep(0.5)
 
@@ -75,7 +80,11 @@ class Desk:
             IdasenDesk.MAX_HEIGHT - IdasenDesk.MIN_HEIGHT
         ) * (heigh_percent / 100)
 
-        await self._idasen_desk.move_to_target(height)
+        try:
+            await self._idasen_desk.wakeup()
+            await self._idasen_desk.move_to_target(height)
+        except (BleakError, TimeoutError):
+            _LOGGER.warning("Failed to move desk", exc_info=True)
 
     async def move_up(self) -> None:
         """Move the desk up."""

--- a/idasen_ha/__init__.py
+++ b/idasen_ha/__init__.py
@@ -154,10 +154,6 @@ class Desk:
     def _create_connection_manager(self, ble_device: BLEDevice) -> ConnectionManager:
         async def connect_callback() -> None:
             _LOGGER.debug("Connect callback called")
-            if self._idasen_desk is None:
-                _LOGGER.error("Desk is None after connecting")
-                return
-
             if self._monitor_height:
                 self._height = await self._idasen_desk.get_height()
                 await self._start_monitoring()

--- a/idasen_ha/__init__.py
+++ b/idasen_ha/__init__.py
@@ -154,6 +154,10 @@ class Desk:
     def _create_connection_manager(self, ble_device: BLEDevice) -> ConnectionManager:
         async def connect_callback() -> None:
             _LOGGER.debug("Connect callback called")
+            if self._idasen_desk is None:  # pragma: no cover
+                _LOGGER.error("Desk is None after connecting")
+                return
+
             if self._monitor_height:
                 self._height = await self._idasen_desk.get_height()
                 await self._start_monitoring()

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -6,6 +6,7 @@ import logging
 from typing import Callable
 
 from bleak.backends.device import BLEDevice
+from bleak.backends.service import BleakGATTServiceCollection
 from bleak.exc import BleakDBusError, BleakError
 from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 from idasen import IdasenDesk
@@ -28,7 +29,7 @@ class ConnectionManager:
         self._keep_connected: bool = False
         self._connecting: bool = False
         self._retry_pending: bool = False
-        self._cached_services = None
+        self._cached_services: BleakGATTServiceCollection | None = None
 
         self._ble_device: BLEDevice = ble_device
         self._idasen_desk: IdasenDesk = self._create_idasen_desk(ble_device)

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -106,20 +106,6 @@ class ConnectionManager:
                     return
                 raise ex
 
-            try:
-                # Wakeup after pair so BLE authentication completes before
-                # writing to GATT characteristics. IdasenDesk.connect()
-                # normally does this immediately, which fails through
-                # Bluetooth proxies that require bonding first.
-                await self._idasen_desk.wakeup()
-            except (TimeoutError, BleakError) as ex:
-                _LOGGER.exception("Wakeup failed")
-                await self._idasen_desk.disconnect()
-                if retry:
-                    self._schedule_reconnect()
-                    return
-                raise ex
-
             await self._handle_connect()
         finally:
             self._connecting = False

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -5,10 +5,9 @@ from collections.abc import Awaitable
 import logging
 from typing import Callable
 
-from bleak import BleakClient
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
-from bleak_retry_connector import establish_connection
+from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 from idasen import IdasenDesk
 
 from .errors import AuthFailedError
@@ -29,6 +28,7 @@ class ConnectionManager:
         self._keep_connected: bool = False
         self._connecting: bool = False
         self._retry_pending: bool = False
+        self._cached_services = None
 
         self._ble_device: BLEDevice = ble_device
         self._idasen_desk: IdasenDesk = self._create_idasen_desk(ble_device)
@@ -69,11 +69,13 @@ class ConnectionManager:
             try:
                 _LOGGER.info("Connecting...")
                 client = await establish_connection(
-                    BleakClient,
+                    BleakClientWithServiceCache,
                     self._ble_device,
                     self._ble_device.address,
                     disconnected_callback=lambda _: self._handle_disconnect(),
+                    cached_services=self._cached_services,
                 )
+                self._cached_services = client.services
                 self._idasen_desk._client = client
             except (TimeoutError, BleakError) as ex:
                 _LOGGER.exception("Connect failed")

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -5,8 +5,10 @@ from collections.abc import Awaitable
 import logging
 from typing import Callable
 
+from bleak import BleakClient
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
+from bleak_retry_connector import establish_connection
 from idasen import IdasenDesk
 
 from .errors import AuthFailedError
@@ -28,6 +30,7 @@ class ConnectionManager:
         self._connecting: bool = False
         self._retry_pending: bool = False
 
+        self._ble_device: BLEDevice = ble_device
         self._idasen_desk: IdasenDesk = self._create_idasen_desk(ble_device)
 
         self._connect_callback = connect_callback
@@ -50,11 +53,7 @@ class ConnectionManager:
             await self._idasen_desk.disconnect()
 
     def _create_idasen_desk(self, ble_device: BLEDevice) -> IdasenDesk:
-        return IdasenDesk(
-            ble_device,
-            exit_on_fail=False,
-            disconnected_callback=lambda bledevice: self._handle_disconnect(),
-        )
+        return IdasenDesk(ble_device, exit_on_fail=False)
 
     async def _connect(self, retry: bool) -> None:
         if self._idasen_desk.is_connected:
@@ -69,7 +68,14 @@ class ConnectionManager:
         try:
             try:
                 _LOGGER.info("Connecting...")
-                await self._idasen_desk.connect()
+                client = await establish_connection(
+                    BleakClient,
+                    self._ble_device,
+                    self._ble_device.address,
+                    disconnected_callback=lambda _: self._handle_disconnect(),
+                )
+                self._idasen_desk._client = client
+                await self._idasen_desk.wakeup()
             except (TimeoutError, BleakError) as ex:
                 _LOGGER.exception("Connect failed")
                 if retry:

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -106,6 +106,20 @@ class ConnectionManager:
                     return
                 raise ex
 
+            try:
+                # Wakeup after pair so BLE authentication completes before
+                # writing to GATT characteristics. IdasenDesk.connect()
+                # normally does this immediately, which fails through
+                # Bluetooth proxies that require bonding first.
+                await self._idasen_desk.wakeup()
+            except (TimeoutError, BleakError) as ex:
+                _LOGGER.exception("Wakeup failed")
+                await self._idasen_desk.disconnect()
+                if retry:
+                    self._schedule_reconnect()
+                    return
+                raise ex
+
             await self._handle_connect()
         finally:
             self._connecting = False

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -75,7 +75,6 @@ class ConnectionManager:
                     disconnected_callback=lambda _: self._handle_disconnect(),
                 )
                 self._idasen_desk._client = client
-                await self._idasen_desk.wakeup()
             except (TimeoutError, BleakError) as ex:
                 _LOGGER.exception("Connect failed")
                 if retry:
@@ -86,6 +85,7 @@ class ConnectionManager:
             try:
                 _LOGGER.info("Pairing...")
                 await self._idasen_desk.pair()
+                await self._idasen_desk.wakeup()
             except BleakDBusError as ex:
                 _LOGGER.exception("Pair failed")
                 await self._idasen_desk.disconnect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "idasen>=0.10,<=0.12.0"
+    "idasen>=0.10,<=0.12.0",
+    "bleak-retry-connector>=3.0",
 ]
 
 [project.readme]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "idasen-ha"
-version = "2.6.4"
+version = "2.6.5"
 license = "MIT"
 authors = [{name = "Abílio Costa", email = "amfcalt@gmail.com"}]
 description = "Home Assistant helper lib for the IKEA Idasen Desk integration"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "idasen-ha"
-version = "2.6.5"
+version = "2.6.4"
 license = "MIT"
 authors = [{name = "Abílio Costa", email = "amfcalt@gmail.com"}]
 description = "Home Assistant helper lib for the IKEA Idasen Desk integration"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 idasen>=0.10,<=0.12.0
+bleak-retry-connector>=3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,8 @@ async def mock_idasen_desk():
         async def mock_monitor(callback: Callable[[float], Awaitable[None]]) -> None:
             mock_desk.trigger_monitor_callback = callback
 
-        # Alias establish_connection as mock_desk.connect for test compatibility
-        mock_desk.connect = mock_establish_connection
+        # Alias establish_connection for test assertions
+        mock_desk.establish_connection = mock_establish_connection
         mock_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
         mock_desk.monitor = AsyncMock(side_effect=mock_monitor)
         mock_desk.wakeup = AsyncMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,10 @@
 """Generic test fixtures."""
 
 from collections.abc import Awaitable
-from typing import Callable, Optional
+from typing import Callable
 from unittest import mock
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
-from bleak import BleakClient
 from idasen import IdasenDesk
 import pytest
 
@@ -16,36 +15,43 @@ async def mock_idasen_desk():
 
     with mock.patch(
         "idasen_ha.connection_manager.IdasenDesk", autospec=True
-    ) as patched_idasen_desk:
+    ) as patched_idasen_desk, mock.patch(
+        "idasen_ha.connection_manager.establish_connection"
+    ) as mock_establish_connection:
         patched_idasen_desk.MIN_HEIGHT = IdasenDesk.MIN_HEIGHT
         patched_idasen_desk.MAX_HEIGHT = IdasenDesk.MAX_HEIGHT
 
         mock_desk = patched_idasen_desk.return_value
 
-        def mock_init(
-            mac_bledevice,
-            exit_on_fail: bool = False,
-            disconnected_callback: Optional[Callable[[BleakClient], None]] = None,
-        ):
-            mock_desk.trigger_disconnected_callback = disconnected_callback
+        def mock_init(mac_bledevice, exit_on_fail: bool = False):
             return mock_desk
 
         patched_idasen_desk.side_effect = mock_init
 
-        async def mock_connect():
+        async def mock_establish_conn(
+            client_class, ble_device, address, disconnected_callback=None, **kwargs
+        ):
+            mock_desk.trigger_disconnected_callback = disconnected_callback
             mock_desk.is_connected = True
+            return MagicMock()
+
+        mock_establish_connection.side_effect = mock_establish_conn
 
         async def mock_disconnect():
             mock_desk.is_connected = False
-            mock_desk.trigger_disconnected_callback(None)
+            if mock_desk.trigger_disconnected_callback:
+                mock_desk.trigger_disconnected_callback(None)
 
         async def mock_monitor(callback: Callable[[float], Awaitable[None]]) -> None:
             mock_desk.trigger_monitor_callback = callback
 
-        mock_desk.connect = AsyncMock(side_effect=mock_connect)
+        # Alias establish_connection as mock_desk.connect for test compatibility
+        mock_desk.connect = mock_establish_connection
         mock_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
         mock_desk.monitor = AsyncMock(side_effect=mock_monitor)
+        mock_desk.wakeup = AsyncMock()
         mock_desk.is_connected = False
         mock_desk.is_moving = False
+        mock_desk.trigger_disconnected_callback = None
 
         yield mock_desk

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,11 +13,14 @@ import pytest
 async def mock_idasen_desk():
     """Test height monitoring."""
 
-    with mock.patch(
-        "idasen_ha.connection_manager.IdasenDesk", autospec=True
-    ) as patched_idasen_desk, mock.patch(
-        "idasen_ha.connection_manager.establish_connection"
-    ) as mock_establish_connection:
+    with (
+        mock.patch(
+            "idasen_ha.connection_manager.IdasenDesk", autospec=True
+        ) as patched_idasen_desk,
+        mock.patch(
+            "idasen_ha.connection_manager.establish_connection"
+        ) as mock_establish_connection,
+    ):
         patched_idasen_desk.MIN_HEIGHT = IdasenDesk.MIN_HEIGHT
         patched_idasen_desk.MAX_HEIGHT = IdasenDesk.MAX_HEIGHT
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ async def mock_idasen_desk():
         # Alias establish_connection for test assertions
         mock_desk.establish_connection = mock_establish_connection
         mock_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
+        mock_desk.wakeup = AsyncMock()
         mock_desk.monitor = AsyncMock(side_effect=mock_monitor)
         mock_desk.wakeup = AsyncMock()
         mock_desk.is_connected = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,6 @@ async def mock_idasen_desk():
         # Alias establish_connection for test assertions
         mock_desk.establish_connection = mock_establish_connection
         mock_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
-        mock_desk.wakeup = AsyncMock()
         mock_desk.monitor = AsyncMock(side_effect=mock_monitor)
         mock_desk.wakeup = AsyncMock()
         mock_desk.is_connected = False

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -173,6 +173,7 @@ async def test_wakeup_called_after_pair(mock_idasen_desk: MagicMock):
     [
         (Exception(), Exception),
         (BleakDBusError("org.bluez.Error.AuthenticationFailed", ""), AuthFailedError),
+        (BleakDBusError("org.bluez.Error.Failed", ""), BleakDBusError),
     ],
 )
 async def test_disconnect_on_pair_failure(
@@ -186,6 +187,29 @@ async def test_disconnect_on_pair_failure(
     with pytest.raises(raised_exception):
         await desk.connect(FAKE_BLE_DEVICE, retry=False)
     assert not desk.is_connected
+    mock_idasen_desk.disconnect.assert_called()
+    mock_idasen_desk.wakeup.assert_not_called()
+    assert update_callback.call_count == 0
+
+
+async def test_wakeup_happens_after_pair(mock_idasen_desk: MagicMock):
+    """Test that wakeup is awaited after pairing succeeds."""
+    desk = Desk(Mock(), False)
+    await desk.connect(FAKE_BLE_DEVICE)
+    mock_idasen_desk.assert_has_calls([call.pair(), call.wakeup()])
+
+
+async def test_disconnect_on_wakeup_failure(mock_idasen_desk: MagicMock):
+    """Test that disconnect is called if wakeup fails."""
+    update_callback = Mock()
+    desk = Desk(update_callback, False)
+
+    mock_idasen_desk.wakeup.side_effect = BleakError()
+
+    with pytest.raises(BleakError):
+        await desk.connect(FAKE_BLE_DEVICE, retry=False)
+
+    mock_idasen_desk.pair.assert_called_once()
     mock_idasen_desk.disconnect.assert_called()
     assert update_callback.call_count == 0
 
@@ -229,7 +253,10 @@ async def test_connect_exception_retry_with_disconnect(
 
     desk = Desk(Mock(), False)
 
-    getattr(mock_idasen_desk, fail_call_name).side_effect = exception
+    fail_target = mock_idasen_desk
+    for attr in fail_call_name.split("."):
+        fail_target = getattr(fail_target, attr)
+    fail_target.side_effect = exception
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
@@ -258,20 +285,22 @@ async def test_connect_exception_retry_success(
     retry_count = 0
     retry_maxed_future = asyncio.Future()
 
-    fail_call = getattr(mock_idasen_desk, fail_call_name)
-    default_fail_call_side_effect = fail_call.side_effect
+    fail_target = mock_idasen_desk
+    for attr in fail_call_name.split("."):
+        fail_target = getattr(fail_target, attr)
+    default_fail_call_side_effect = fail_target.side_effect
 
     async def sleep_handler(delay):
         nonlocal retry_count
         if retry_count == TEST_RETRIES_MAX:
-            fail_call.side_effect = default_fail_call_side_effect
+            fail_target.side_effect = default_fail_call_side_effect
             retry_maxed_future.set_result(None)
         retry_count = retry_count + 1
 
     sleep_mock.side_effect = sleep_handler
 
     desk = Desk(Mock(), False)
-    fail_call.side_effect = exception
+    fail_target.side_effect = exception
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -305,7 +305,6 @@ async def test_reconnect_aborted_when_disconnected(
     mock_idasen_desk: MagicMock,
 ) -> None:
     """Test that a scheduled reconnect is aborted if keep_connected becomes False."""
-    import asyncio as real_asyncio
 
     async def sleep_side_effect(delay):
         pass
@@ -322,8 +321,8 @@ async def test_reconnect_aborted_when_disconnected(
     mock_idasen_desk.establish_connection.side_effect = None
 
     # Yield to let the pending _reconnect task run and observe _keep_connected=False
-    await real_asyncio.sleep(0)
-    await real_asyncio.sleep(0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
 
     # Only the initial failed attempt; no reconnect since _keep_connected=False
     assert mock_idasen_desk.establish_connection.call_count == 1

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -278,6 +278,57 @@ async def test_connect_exception_retry_success(
     assert mock_idasen_desk.establish_connection.call_count == TEST_RETRIES_MAX + 2
 
 
+async def test_non_auth_dbus_error_raises(mock_idasen_desk: MagicMock):
+    """Test that a non-auth BleakDBusError is re-raised when retry=False."""
+    desk = Desk(Mock(), False)
+
+    mock_idasen_desk.pair.side_effect = BleakDBusError("org.bluez.Error.Failed", [])
+    with pytest.raises(BleakDBusError):
+        await desk.connect(FAKE_BLE_DEVICE, retry=False)
+    mock_idasen_desk.disconnect.assert_called()
+
+
+async def test_schedule_reconnect_already_pending(mock_idasen_desk: MagicMock):
+    """Test that scheduling a reconnect when one is already pending is a no-op."""
+    desk = Desk(Mock(), False)
+    await desk.connect(FAKE_BLE_DEVICE)
+
+    cm = desk._connection_manager
+    cm._retry_pending = True
+    cm._schedule_reconnect()  # should return early without creating a second task
+    assert cm._retry_pending is True
+
+
+@mock.patch("idasen_ha.connection_manager.asyncio.sleep")
+async def test_reconnect_aborted_when_disconnected(
+    sleep_mock,
+    mock_idasen_desk: MagicMock,
+) -> None:
+    """Test that a scheduled reconnect is aborted if keep_connected becomes False."""
+    import asyncio as real_asyncio
+
+    async def sleep_side_effect(delay):
+        pass
+
+    sleep_mock.side_effect = sleep_side_effect
+
+    desk = Desk(Mock(), False)
+    mock_idasen_desk.establish_connection.side_effect = TimeoutError()
+    await desk.connect(FAKE_BLE_DEVICE)
+    assert not desk.is_connected
+
+    await desk.disconnect()  # sets _keep_connected = False
+
+    mock_idasen_desk.establish_connection.side_effect = None
+
+    # Yield to let the pending _reconnect task run and observe _keep_connected=False
+    await real_asyncio.sleep(0)
+    await real_asyncio.sleep(0)
+
+    # Only the initial failed attempt; no reconnect since _keep_connected=False
+    assert mock_idasen_desk.establish_connection.call_count == 1
+
+
 async def test_reconnect_on_connection_drop(mock_idasen_desk: MagicMock):
     """Test reconnection when the connection drops."""
     update_callback = Mock()

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -173,7 +173,6 @@ async def test_wakeup_called_after_pair(mock_idasen_desk: MagicMock):
     [
         (Exception(), Exception),
         (BleakDBusError("org.bluez.Error.AuthenticationFailed", ""), AuthFailedError),
-        (BleakDBusError("org.bluez.Error.Failed", ""), BleakDBusError),
     ],
 )
 async def test_disconnect_on_pair_failure(
@@ -187,29 +186,6 @@ async def test_disconnect_on_pair_failure(
     with pytest.raises(raised_exception):
         await desk.connect(FAKE_BLE_DEVICE, retry=False)
     assert not desk.is_connected
-    mock_idasen_desk.disconnect.assert_called()
-    mock_idasen_desk.wakeup.assert_not_called()
-    assert update_callback.call_count == 0
-
-
-async def test_wakeup_happens_after_pair(mock_idasen_desk: MagicMock):
-    """Test that wakeup is awaited after pairing succeeds."""
-    desk = Desk(Mock(), False)
-    await desk.connect(FAKE_BLE_DEVICE)
-    mock_idasen_desk.assert_has_calls([call.pair(), call.wakeup()])
-
-
-async def test_disconnect_on_wakeup_failure(mock_idasen_desk: MagicMock):
-    """Test that disconnect is called if wakeup fails."""
-    update_callback = Mock()
-    desk = Desk(update_callback, False)
-
-    mock_idasen_desk.wakeup.side_effect = BleakError()
-
-    with pytest.raises(BleakError):
-        await desk.connect(FAKE_BLE_DEVICE, retry=False)
-
-    mock_idasen_desk.pair.assert_called_once()
     mock_idasen_desk.disconnect.assert_called()
     assert update_callback.call_count == 0
 
@@ -253,10 +229,7 @@ async def test_connect_exception_retry_with_disconnect(
 
     desk = Desk(Mock(), False)
 
-    fail_target = mock_idasen_desk
-    for attr in fail_call_name.split("."):
-        fail_target = getattr(fail_target, attr)
-    fail_target.side_effect = exception
+    getattr(mock_idasen_desk, fail_call_name).side_effect = exception
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
@@ -285,22 +258,20 @@ async def test_connect_exception_retry_success(
     retry_count = 0
     retry_maxed_future = asyncio.Future()
 
-    fail_target = mock_idasen_desk
-    for attr in fail_call_name.split("."):
-        fail_target = getattr(fail_target, attr)
-    default_fail_call_side_effect = fail_target.side_effect
+    fail_call = getattr(mock_idasen_desk, fail_call_name)
+    default_fail_call_side_effect = fail_call.side_effect
 
     async def sleep_handler(delay):
         nonlocal retry_count
         if retry_count == TEST_RETRIES_MAX:
-            fail_target.side_effect = default_fail_call_side_effect
+            fail_call.side_effect = default_fail_call_side_effect
             retry_maxed_future.set_result(None)
         retry_count = retry_count + 1
 
     sleep_mock.side_effect = sleep_handler
 
     desk = Desk(Mock(), False)
-    fail_target.side_effect = exception
+    fail_call.side_effect = exception
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -69,11 +69,14 @@ async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMo
 async def test_double_connect_call_with_different_bledevice():
     """Test connect being called again with a new BLEDevice, while still connecting."""
 
-    with mock.patch(
-        "idasen_ha.connection_manager.IdasenDesk", autospec=True
-    ) as patched_idasen_desk, mock.patch(
-        "idasen_ha.connection_manager.establish_connection"
-    ) as mock_establish_connection:
+    with (
+        mock.patch(
+            "idasen_ha.connection_manager.IdasenDesk", autospec=True
+        ) as patched_idasen_desk,
+        mock.patch(
+            "idasen_ha.connection_manager.establish_connection"
+        ) as mock_establish_connection,
+    ):
         mock_idasen_desk = patched_idasen_desk.return_value
         mock_idasen_desk.is_connected = False
         mock_idasen_desk.wakeup = AsyncMock()
@@ -83,7 +86,9 @@ async def test_double_connect_call_with_different_bledevice():
 
         mock_idasen_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
 
-        async def first_establish_side_effect(client_class, ble_device, address, **kwargs):
+        async def first_establish_side_effect(
+            client_class, ble_device, address, **kwargs
+        ):
             # Switch side effect so subsequent establish_connection calls succeed simply
             async def subsequent_establish(*args, **kw):
                 mock_idasen_desk.is_connected = True

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -229,10 +229,7 @@ async def test_connect_exception_retry_with_disconnect(
 
     desk = Desk(Mock(), False)
 
-    fail_target = mock_idasen_desk
-    for attr in fail_call_name.split("."):
-        fail_target = getattr(fail_target, attr)
-    fail_target.side_effect = exception
+    getattr(mock_idasen_desk, fail_call_name).side_effect = exception
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
@@ -261,22 +258,20 @@ async def test_connect_exception_retry_success(
     retry_count = 0
     retry_maxed_future = asyncio.Future()
 
-    fail_target = mock_idasen_desk
-    for attr in fail_call_name.split("."):
-        fail_target = getattr(fail_target, attr)
-    default_fail_call_side_effect = fail_target.side_effect
+    fail_call = getattr(mock_idasen_desk, fail_call_name)
+    default_fail_call_side_effect = fail_call.side_effect
 
     async def sleep_handler(delay):
         nonlocal retry_count
         if retry_count == TEST_RETRIES_MAX:
-            fail_target.side_effect = default_fail_call_side_effect
+            fail_call.side_effect = default_fail_call_side_effect
             retry_maxed_future.set_result(None)
         retry_count = retry_count + 1
 
     sleep_mock.side_effect = sleep_handler
 
     desk = Desk(Mock(), False)
-    fail_target.side_effect = exception
+    fail_call.side_effect = exception
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -21,8 +21,9 @@ async def test_connect_disconnect(mock_idasen_desk: MagicMock):
 
     await desk.connect(FAKE_BLE_DEVICE)
     assert desk.is_connected
-    mock_idasen_desk.connect.assert_awaited()
+    mock_idasen_desk.establish_connection.assert_awaited()
     mock_idasen_desk.pair.assert_called()
+    mock_idasen_desk.wakeup.assert_awaited()
     assert update_callback.call_count == 1
 
     await desk.disconnect()
@@ -40,8 +41,9 @@ async def test_connect_skipped_when_already_connected(mock_idasen_desk: MagicMoc
     mock_idasen_desk.is_connected = True
 
     await desk.connect(FAKE_BLE_DEVICE)
-    mock_idasen_desk.connect.assert_not_awaited()
+    mock_idasen_desk.establish_connection.assert_not_awaited()
     mock_idasen_desk.pair.assert_not_called()
+    mock_idasen_desk.wakeup.assert_not_called()
     assert update_callback.call_count == 0
 
 
@@ -50,19 +52,20 @@ async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMo
     update_callback = Mock()
     desk = Desk(update_callback, False)
 
-    default_connect_side_effect = mock_idasen_desk.connect.side_effect
+    default_connect_side_effect = mock_idasen_desk.establish_connection.side_effect
 
     async def connect_side_effect(*args, **kwargs):
         # call the seccond `connect` while the first is ongoing
         await desk.connect(FAKE_BLE_DEVICE)
         await default_connect_side_effect(*args, **kwargs)
 
-    mock_idasen_desk.connect.side_effect = connect_side_effect
+    mock_idasen_desk.establish_connection.side_effect = connect_side_effect
 
     await desk.connect(FAKE_BLE_DEVICE)
     assert desk.is_connected
-    mock_idasen_desk.connect.assert_awaited()
+    mock_idasen_desk.establish_connection.assert_awaited()
     mock_idasen_desk.pair.assert_called()
+    mock_idasen_desk.wakeup.assert_awaited()
     assert update_callback.call_count == 1
 
 
@@ -109,6 +112,7 @@ async def test_double_connect_call_with_different_bledevice():
 
         mock_establish_connection.assert_awaited()
         mock_idasen_desk.pair.assert_called()
+        mock_idasen_desk.wakeup.assert_awaited()
         assert update_callback.call_count == 2
         assert patched_idasen_desk.call_count == 2
 
@@ -123,22 +127,22 @@ async def test_connect_called_while_retry_pending(
     update_callback = Mock()
     desk = Desk(update_callback, False)
 
-    default_connect_side_effect = mock_idasen_desk.connect.side_effect
+    default_connect_side_effect = mock_idasen_desk.establish_connection.side_effect
 
     async def sleep_side_effect(delay):
-        mock_idasen_desk.connect.side_effect = default_connect_side_effect
+        mock_idasen_desk.establish_connection.side_effect = default_connect_side_effect
         await desk.connect(FAKE_BLE_DEVICE)
         retry_maxed_future.set_result(None)
 
     sleep_mock.side_effect = sleep_side_effect
 
-    mock_idasen_desk.connect.side_effect = TimeoutError()
+    mock_idasen_desk.establish_connection.side_effect = TimeoutError()
     await desk.connect(FAKE_BLE_DEVICE)
     assert not desk.is_connected
 
     await retry_maxed_future
     assert desk.is_connected
-    assert mock_idasen_desk.connect.call_count == 2
+    assert mock_idasen_desk.establish_connection.call_count == 2
     assert update_callback.call_count == 1
 
 
@@ -146,10 +150,22 @@ async def test_connect_raises_without_auto_reconnect(mock_idasen_desk: MagicMock
     """Test that connect raises if auto_reconnect is False."""
     desk = Desk(Mock(), False)
 
-    mock_idasen_desk.connect.side_effect = TimeoutError()
+    mock_idasen_desk.establish_connection.side_effect = TimeoutError()
     with pytest.raises(TimeoutError):
         await desk.connect(FAKE_BLE_DEVICE, retry=False)
     assert not desk.is_connected
+
+
+async def test_wakeup_called_after_pair(mock_idasen_desk: MagicMock):
+    """Test that wakeup is called after pair, not before."""
+    call_order = []
+    mock_idasen_desk.pair = AsyncMock(side_effect=lambda: call_order.append("pair"))
+    mock_idasen_desk.wakeup = AsyncMock(side_effect=lambda: call_order.append("wakeup"))
+
+    desk = Desk(Mock(), False)
+    await desk.connect(FAKE_BLE_DEVICE)
+
+    assert call_order == ["pair", "wakeup"]
 
 
 @pytest.mark.parametrize(
@@ -174,9 +190,23 @@ async def test_disconnect_on_pair_failure(
     assert update_callback.call_count == 0
 
 
+async def test_disconnect_on_wakeup_failure(mock_idasen_desk: MagicMock):
+    """Test that disconnect is called if wakeup fails after pairing."""
+    update_callback = Mock()
+    desk = Desk(update_callback, False)
+
+    mock_idasen_desk.wakeup.side_effect = BleakError()
+    with pytest.raises(BleakError):
+        await desk.connect(FAKE_BLE_DEVICE, retry=False)
+    assert not desk.is_connected
+    mock_idasen_desk.pair.assert_called()
+    mock_idasen_desk.disconnect.assert_called()
+    assert update_callback.call_count == 0
+
+
 @mock.patch("idasen_ha.connection_manager.asyncio.sleep")
 @pytest.mark.parametrize("exception", [TimeoutError(), BleakError()])
-@pytest.mark.parametrize("fail_call_name", ["connect", "pair"])
+@pytest.mark.parametrize("fail_call_name", ["establish_connection", "pair", "wakeup"])
 async def test_connect_exception_retry_with_disconnect(
     sleep_mock,
     mock_idasen_desk: MagicMock,
@@ -203,7 +233,7 @@ async def test_connect_exception_retry_with_disconnect(
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
-    assert mock_idasen_desk.connect.call_count == TEST_RETRIES_MAX + 1
+    assert mock_idasen_desk.establish_connection.call_count == TEST_RETRIES_MAX + 1
 
 
 @mock.patch("idasen_ha.connection_manager.asyncio.sleep")
@@ -216,7 +246,7 @@ async def test_connect_exception_retry_with_disconnect(
         BleakDBusError("org.bluez.Error.AuthenticationFailed", []),
     ],
 )
-@pytest.mark.parametrize("fail_call_name", ["connect", "pair"])
+@pytest.mark.parametrize("fail_call_name", ["establish_connection", "pair", "wakeup"])
 async def test_connect_exception_retry_success(
     sleep_mock,
     mock_idasen_desk: MagicMock,
@@ -245,7 +275,7 @@ async def test_connect_exception_retry_success(
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
-    assert mock_idasen_desk.connect.call_count == TEST_RETRIES_MAX + 2
+    assert mock_idasen_desk.establish_connection.call_count == TEST_RETRIES_MAX + 2
 
 
 async def test_reconnect_on_connection_drop(mock_idasen_desk: MagicMock):
@@ -258,13 +288,14 @@ async def test_reconnect_on_connection_drop(mock_idasen_desk: MagicMock):
     assert update_callback.call_count == 1
 
     mock_idasen_desk.reset_mock()
-    mock_idasen_desk.connect.reset_mock()  # establish_connection is external, reset separately
+    mock_idasen_desk.establish_connection.reset_mock()  # establish_connection is external, reset separately
     await mock_idasen_desk.disconnect()
     assert not desk.is_connected
     assert update_callback.call_count == 2
 
     await asyncio.sleep(0)
     assert desk.is_connected
-    mock_idasen_desk.connect.assert_awaited()
+    mock_idasen_desk.establish_connection.assert_awaited()
     mock_idasen_desk.pair.assert_called()
+    mock_idasen_desk.wakeup.assert_awaited()
     assert update_callback.call_count == 3

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from unittest import mock
-from unittest.mock import MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
@@ -52,10 +52,10 @@ async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMo
 
     default_connect_side_effect = mock_idasen_desk.connect.side_effect
 
-    async def connect_side_effect():
+    async def connect_side_effect(*args, **kwargs):
         # call the seccond `connect` while the first is ongoing
         await desk.connect(FAKE_BLE_DEVICE)
-        await default_connect_side_effect()
+        await default_connect_side_effect(*args, **kwargs)
 
     mock_idasen_desk.connect.side_effect = connect_side_effect
 
@@ -71,23 +71,38 @@ async def test_double_connect_call_with_different_bledevice():
 
     with mock.patch(
         "idasen_ha.connection_manager.IdasenDesk", autospec=True
-    ) as patched_idasen_desk:
+    ) as patched_idasen_desk, mock.patch(
+        "idasen_ha.connection_manager.establish_connection"
+    ) as mock_establish_connection:
         mock_idasen_desk = patched_idasen_desk.return_value
+        mock_idasen_desk.is_connected = False
+        mock_idasen_desk.wakeup = AsyncMock()
 
-        async def connect_side_effect():
-            # call the seccond `connect` while the first is ongoing
-            mock_idasen_desk.connect.side_effect = MagicMock()
+        async def mock_disconnect():
+            mock_idasen_desk.is_connected = False
+
+        mock_idasen_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
+
+        async def first_establish_side_effect(client_class, ble_device, address, **kwargs):
+            # Switch side effect so subsequent establish_connection calls succeed simply
+            async def subsequent_establish(*args, **kw):
+                mock_idasen_desk.is_connected = True
+                return MagicMock()
+
+            mock_establish_connection.side_effect = subsequent_establish
+            # Call the second connect with a different BLE device while first is in progress
             new_ble_device = BLEDevice("AA:BB:CC:DD:EE:AA", None, None)
             await desk.connect(new_ble_device)
+            mock_idasen_desk.is_connected = True
+            return MagicMock()
 
-        mock_idasen_desk.is_connected = False
-        mock_idasen_desk.connect.side_effect = connect_side_effect
+        mock_establish_connection.side_effect = first_establish_side_effect
 
         update_callback = Mock()
         desk = Desk(update_callback, False)
         await desk.connect(FAKE_BLE_DEVICE)
 
-        mock_idasen_desk.connect.assert_awaited()
+        mock_establish_connection.assert_awaited()
         mock_idasen_desk.pair.assert_called()
         assert update_callback.call_count == 2
         assert patched_idasen_desk.call_count == 2
@@ -238,6 +253,7 @@ async def test_reconnect_on_connection_drop(mock_idasen_desk: MagicMock):
     assert update_callback.call_count == 1
 
     mock_idasen_desk.reset_mock()
+    mock_idasen_desk.connect.reset_mock()  # establish_connection is external, reset separately
     await mock_idasen_desk.disconnect()
     assert not desk.is_connected
     assert update_callback.call_count == 2

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -57,7 +57,7 @@ async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMo
     async def connect_side_effect(*args, **kwargs):
         # call the seccond `connect` while the first is ongoing
         await desk.connect(FAKE_BLE_DEVICE)
-        await default_connect_side_effect(*args, **kwargs)
+        return await default_connect_side_effect(*args, **kwargs)
 
     mock_idasen_desk.establish_connection.side_effect = connect_side_effect
 

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -173,7 +173,6 @@ async def test_wakeup_called_after_pair(mock_idasen_desk: MagicMock):
     [
         (Exception(), Exception),
         (BleakDBusError("org.bluez.Error.AuthenticationFailed", ""), AuthFailedError),
-        (BleakDBusError("org.bluez.Error.Failed", ""), BleakDBusError),
     ],
 )
 async def test_disconnect_on_pair_failure(
@@ -187,29 +186,6 @@ async def test_disconnect_on_pair_failure(
     with pytest.raises(raised_exception):
         await desk.connect(FAKE_BLE_DEVICE, retry=False)
     assert not desk.is_connected
-    mock_idasen_desk.disconnect.assert_called()
-    mock_idasen_desk.wakeup.assert_not_called()
-    assert update_callback.call_count == 0
-
-
-async def test_wakeup_happens_after_pair(mock_idasen_desk: MagicMock):
-    """Test that wakeup is awaited after pairing succeeds."""
-    desk = Desk(Mock(), False)
-    await desk.connect(FAKE_BLE_DEVICE)
-    mock_idasen_desk.assert_has_calls([call.pair(), call.wakeup()])
-
-
-async def test_disconnect_on_wakeup_failure(mock_idasen_desk: MagicMock):
-    """Test that disconnect is called if wakeup fails."""
-    update_callback = Mock()
-    desk = Desk(update_callback, False)
-
-    mock_idasen_desk.wakeup.side_effect = BleakError()
-
-    with pytest.raises(BleakError):
-        await desk.connect(FAKE_BLE_DEVICE, retry=False)
-
-    mock_idasen_desk.pair.assert_called_once()
     mock_idasen_desk.disconnect.assert_called()
     assert update_callback.call_count == 0
 

--- a/tests/test_desk_functions.py
+++ b/tests/test_desk_functions.py
@@ -3,8 +3,8 @@
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, Mock
 
-import pytest
 from bleak.exc import BleakError
+import pytest
 
 from idasen_ha import Desk
 

--- a/tests/test_desk_functions.py
+++ b/tests/test_desk_functions.py
@@ -20,7 +20,7 @@ async def test_monitor_height(mock_idasen_desk: MagicMock):
     mock_idasen_desk.get_height.return_value = HEIGHT_MTS_1
 
     await desk.connect(FAKE_BLE_DEVICE)
-    mock_idasen_desk.connect.assert_called()
+    mock_idasen_desk.establish_connection.assert_called()
     mock_idasen_desk.pair.assert_called()
     mock_idasen_desk.get_height.assert_called()
     update_callback.assert_called_with(HEIGHT_PCT_1)
@@ -70,9 +70,13 @@ async def test_stop_before_move(mock_idasen_desk: MagicMock):
 
     HEIGHT_1 = 50
     await desk.move_to(HEIGHT_1)
-    # ensure stop() is called before move_to_target()
+    # ensure stop() is called, then wakeup(), then move_to_target()
     mock_idasen_desk.assert_has_calls(
-        [mock.call.stop(), mock.call.move_to_target(height_percent_to_meters(HEIGHT_1))]
+        [
+            mock.call.stop(),
+            mock.call.wakeup(),
+            mock.call.move_to_target(height_percent_to_meters(HEIGHT_1)),
+        ]
     )
 
 

--- a/tests/test_desk_functions.py
+++ b/tests/test_desk_functions.py
@@ -1,9 +1,10 @@
 """Tests for idasen_ha."""
 
 from unittest import mock
-from unittest.mock import MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
+from bleak.exc import BleakError
 
 from idasen_ha import Desk
 
@@ -78,6 +79,47 @@ async def test_stop_before_move(mock_idasen_desk: MagicMock):
             mock.call.move_to_target(height_percent_to_meters(HEIGHT_1)),
         ]
     )
+
+
+async def test_stop_failure_before_move(mock_idasen_desk: MagicMock):
+    """Test that move_to returns early when stop raises before moving."""
+    desk = Desk(None, False)
+    await desk.connect(FAKE_BLE_DEVICE)
+
+    mock_idasen_desk.is_moving = True
+    mock_idasen_desk.stop = AsyncMock(side_effect=BleakError())
+
+    await desk.move_to(50)
+    mock_idasen_desk.move_to_target.assert_not_called()
+
+
+async def test_move_to_failure(mock_idasen_desk: MagicMock):
+    """Test that move_to swallows BleakError from move_to_target."""
+    desk = Desk(None, False)
+    await desk.connect(FAKE_BLE_DEVICE)
+
+    mock_idasen_desk.is_moving = False
+    mock_idasen_desk.move_to_target = AsyncMock(side_effect=BleakError())
+
+    await desk.move_to(50)  # should not raise
+
+
+async def test_monitoring_skipped_if_disconnected_during_get_height(
+    mock_idasen_desk: MagicMock,
+):
+    """Test that monitoring is skipped if the desk disconnects during get_height."""
+
+    async def get_height_and_disconnect():
+        # Simulate a BLE disconnect occurring while get_height is in progress
+        mock_idasen_desk.is_connected = False
+        return height_percent_to_meters(50)
+
+    mock_idasen_desk.get_height.side_effect = get_height_and_disconnect
+
+    desk = Desk(Mock(), True)
+    await desk.connect(FAKE_BLE_DEVICE)
+
+    mock_idasen_desk.monitor.assert_not_called()
 
 
 async def test_stop(mock_idasen_desk: MagicMock):


### PR DESCRIPTION
* implement bleak_retry_connector to resolve warnings in HA and potentially improve connections (anecdotally seems more reliable)