### PR TITLE
Use bleak-retry-connector for BLE proxy connections

### DIFF
--- a/idasen_ha/__init__.py
+++ b/idasen_ha/__init__.py
@@ -51,7 +51,7 @@ class Desk:
             self._ble_device = ble_device
             self._connection_manager = self._create_connection_manager(self._ble_device)
 
-        await self._connection_manager.connect(retry)
+        await self._connection_manager.connect(ble_device, retry)
 
     async def disconnect(self) -> None:
         """Disconnect from the desk."""

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -7,6 +7,11 @@ from typing import Callable
 
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
+from bleak_retry_connector import (
+    BleakClientWithServiceCache,
+    close_stale_connections_by_address,
+    establish_connection,
+)
 from idasen import IdasenDesk
 
 from .errors import AuthFailedError
@@ -27,6 +32,7 @@ class ConnectionManager:
         self._keep_connected: bool = False
         self._connecting: bool = False
         self._retry_pending: bool = False
+        self._ble_device = ble_device
 
         self._idasen_desk: IdasenDesk = self._create_idasen_desk(ble_device)
 
@@ -37,6 +43,10 @@ class ConnectionManager:
     def idasen_desk(self) -> IdasenDesk:
         """The IdasenDesk instance."""
         return self._idasen_desk
+
+    def update_ble_device(self, ble_device: BLEDevice) -> None:
+        """Update the BLE device reference (e.g. after rediscovery)."""
+        self._ble_device = ble_device
 
     async def connect(self, retry: bool) -> None:
         """Perform the bluetooth connection to the desk."""
@@ -68,10 +78,15 @@ class ConnectionManager:
         self._connecting = True
         try:
             try:
-                _LOGGER.info("Connecting...")
-                # Connect without wakeup — IdasenDesk.connect() bundles both,
-                # but we need pair() to complete before wakeup().
-                await self._idasen_desk._client.connect()  # noqa: SLF001
+                _LOGGER.info("Connecting via bleak-retry-connector...")
+                await close_stale_connections_by_address(self._ble_device.address)
+                client = await establish_connection(
+                    BleakClientWithServiceCache,
+                    self._ble_device,
+                    self._ble_device.address,
+                    disconnected_callback=lambda _client: self._handle_disconnect(),
+                )
+                self._idasen_desk._client = client  # noqa: SLF001
             except (TimeoutError, BleakError) as ex:
                 _LOGGER.exception("Connect failed")
                 if retry:

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -12,8 +12,8 @@ from bleak_retry_connector import (
     close_stale_connections_by_address,
     establish_connection,
 )
-from idasen import IdasenDesk
 
+from .desk import ManagedIdasenDesk
 from .errors import AuthFailedError
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,13 +34,13 @@ class ConnectionManager:
         self._retry_pending: bool = False
         self._ble_device = ble_device
 
-        self._idasen_desk: IdasenDesk = self._create_idasen_desk(ble_device)
+        self._idasen_desk: ManagedIdasenDesk = self._create_idasen_desk(ble_device)
 
         self._connect_callback = connect_callback
         self._disconnect_callback = disconnect_callback
 
     @property
-    def idasen_desk(self) -> IdasenDesk:
+    def idasen_desk(self) -> ManagedIdasenDesk:
         """The IdasenDesk instance."""
         return self._idasen_desk
 
@@ -55,12 +55,8 @@ class ConnectionManager:
         if self._idasen_desk.is_connected:
             await self._idasen_desk.disconnect()
 
-    def _create_idasen_desk(self, ble_device: BLEDevice) -> IdasenDesk:
-        return IdasenDesk(
-            ble_device,
-            exit_on_fail=False,
-            disconnected_callback=lambda bledevice: self._handle_disconnect(),
-        )
+    def _create_idasen_desk(self, ble_device: BLEDevice) -> ManagedIdasenDesk:
+        return ManagedIdasenDesk(ble_device, exit_on_fail=False)
 
     async def _connect(self, retry: bool) -> None:
         if self._idasen_desk.is_connected:
@@ -82,7 +78,7 @@ class ConnectionManager:
                     self._ble_device.address,
                     disconnected_callback=lambda _client: self._handle_disconnect(),
                 )
-                self._idasen_desk._client = client  # noqa: SLF001
+                self._idasen_desk.set_client(client)
             except (TimeoutError, BleakError) as ex:
                 _LOGGER.exception("Connect failed")
                 if retry:
@@ -111,10 +107,16 @@ class ConnectionManager:
                 raise ex
 
             try:
+<<<<<<< HEAD
                 # Wakeup after pair so BLE authentication completes before
                 # writing to GATT characteristics. IdasenDesk.connect()
                 # normally does this immediately, which fails through
                 # Bluetooth proxies that require bonding first.
+=======
+                # This replaces the wakeup normally done inside IdasenDesk.connect(),
+                # which we intentionally avoid because Bluetooth proxy setups need
+                # pairing/authentication to complete before the wakeup writes.
+>>>>>>> 13938b8 (refactor: encapsulate external BLE client handoff)
                 await self._idasen_desk.wakeup()
             except (TimeoutError, BleakError) as ex:
                 _LOGGER.exception("Wakeup failed")

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -44,8 +44,11 @@ class ConnectionManager:
         """The IdasenDesk instance."""
         return self._idasen_desk
 
-    async def connect(self, retry: bool) -> None:
+    async def connect(self, ble_device: BLEDevice, retry: bool) -> None:
         """Perform the bluetooth connection to the desk."""
+        if ble_device.address != self._ble_device.address:
+            self._ble_device = ble_device
+            self._idasen_desk = self._create_idasen_desk(ble_device)
         self._keep_connected = True
         await self._connect(retry)
 
@@ -178,4 +181,4 @@ class ConnectionManager:
         self._disconnect_callback()
         if self._keep_connected and not self._retry_pending:
             _LOGGER.info("Reconnecting since it should not be disconnected")
-            asyncio.get_event_loop().create_task(self.connect(True))
+            asyncio.get_event_loop().create_task(self.connect(self._ble_device, True))

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -110,16 +110,10 @@ class ConnectionManager:
                 raise ex
 
             try:
-<<<<<<< HEAD
                 # Wakeup after pair so BLE authentication completes before
                 # writing to GATT characteristics. IdasenDesk.connect()
                 # normally does this immediately, which fails through
                 # Bluetooth proxies that require bonding first.
-=======
-                # This replaces the wakeup normally done inside IdasenDesk.connect(),
-                # which we intentionally avoid because Bluetooth proxy setups need
-                # pairing/authentication to complete before the wakeup writes.
->>>>>>> 13938b8 (refactor: encapsulate external BLE client handoff)
                 await self._idasen_desk.wakeup()
             except (TimeoutError, BleakError) as ex:
                 _LOGGER.exception("Wakeup failed")

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -44,10 +44,6 @@ class ConnectionManager:
         """The IdasenDesk instance."""
         return self._idasen_desk
 
-    def update_ble_device(self, ble_device: BLEDevice) -> None:
-        """Update the BLE device reference (e.g. after rediscovery)."""
-        self._ble_device = ble_device
-
     async def connect(self, retry: bool) -> None:
         """Perform the bluetooth connection to the desk."""
         self._keep_connected = True

--- a/idasen_ha/desk.py
+++ b/idasen_ha/desk.py
@@ -33,6 +33,11 @@ class ManagedIdasenDesk(IdasenDesk):
         self._moving = False
         self._move_task: Optional[asyncio.Task] = None
 
+    @property
+    def is_connected(self) -> bool:
+        """Return whether the desk is connected."""
+        return self._client is not None and self._client.is_connected
+
     def set_client(self, client: BleakClient) -> None:
         """Adopt an externally-established BLE client."""
         self._client = client

--- a/idasen_ha/desk.py
+++ b/idasen_ha/desk.py
@@ -1,19 +1,38 @@
 """Idasen desk helpers for Home Assistant integration."""
 
+import asyncio
+import logging
+from typing import Optional, Union
+
 from bleak import BleakClient
-from idasen import IdasenDesk
+from bleak.backends.device import BLEDevice
+from idasen import IdasenDesk, _DeskLoggingAdapter
 
 
 class ManagedIdasenDesk(IdasenDesk):
-    """IdasenDesk variant that can adopt an already-established client."""
+    """IdasenDesk variant whose BLE client is managed externally.
+
+    The upstream ``IdasenDesk.__init__`` creates its own ``BleakClient``, but in
+    Bluetooth proxy flows the connection is established externally via
+    ``bleak-retry-connector``.  This subclass skips the unused client creation
+    and lets the caller inject one later with :meth:`set_client`.
+    """
+
+    def __init__(
+        self,
+        mac: Union[BLEDevice, str],
+        exit_on_fail: bool = False,
+    ):
+        """Initialize without creating a BleakClient."""
+        self._exit_on_fail = exit_on_fail
+        self._client: Optional[BleakClient] = None
+        self._mac = mac.address if isinstance(mac, BLEDevice) else mac
+        self._logger = _DeskLoggingAdapter(
+            logger=logging.getLogger(__name__), extra={"mac": self.mac}
+        )
+        self._moving = False
+        self._move_task: Optional[asyncio.Task] = None
 
     def set_client(self, client: BleakClient) -> None:
-        """Replace the internally-created client with an external one.
-
-        The upstream ``IdasenDesk.connect()`` creates its own ``BleakClient`` and then
-        immediately calls ``wakeup()``. For Bluetooth proxy flows we establish the
-        connection externally and delay ``wakeup()`` until after pairing/authentication
-        completes, so the manager injects the already-connected client here instead of
-        calling ``IdasenDesk.connect()``.
-        """
+        """Adopt an externally-established BLE client."""
         self._client = client

--- a/idasen_ha/desk.py
+++ b/idasen_ha/desk.py
@@ -1,0 +1,19 @@
+"""Idasen desk helpers for Home Assistant integration."""
+
+from bleak import BleakClient
+from idasen import IdasenDesk
+
+
+class ManagedIdasenDesk(IdasenDesk):
+    """IdasenDesk variant that can adopt an already-established client."""
+
+    def set_client(self, client: BleakClient) -> None:
+        """Replace the internally-created client with an external one.
+
+        The upstream ``IdasenDesk.connect()`` creates its own ``BleakClient`` and then
+        immediately calls ``wakeup()``. For Bluetooth proxy flows we establish the
+        connection externally and delay ``wakeup()`` until after pairing/authentication
+        completes, so the manager injects the already-connected client here instead of
+        calling ``IdasenDesk.connect()``.
+        """
+        self._client = client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "idasen>=0.10,<=0.12.0"
+    "idasen>=0.10,<=0.12.0",
+    "bleak-retry-connector>=3.4.0",
 ]
 
 [project.readme]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 idasen>=0.10,<=0.12.0
+bleak-retry-connector>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 idasen>=0.10,<=0.12.0
-bleak-retry-connector>=3.0
+bleak-retry-connector>=3.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ async def mock_idasen_desk():
 
     with (
         mock.patch(
-            "idasen_ha.connection_manager.IdasenDesk", autospec=True
+            "idasen_ha.connection_manager.ManagedIdasenDesk", autospec=True
         ) as patched_idasen_desk,
         mock.patch(
             "idasen_ha.connection_manager.establish_connection"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,10 @@
 """Generic test fixtures."""
 
 from collections.abc import Awaitable
-from typing import Callable, Optional
+from typing import Callable
 from unittest import mock
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
-from bleak import BleakClient
 from idasen import IdasenDesk
 import pytest
 
@@ -14,9 +13,14 @@ import pytest
 async def mock_idasen_desk():
     """Test height monitoring."""
 
-    with mock.patch(
-        "idasen_ha.connection_manager.IdasenDesk", autospec=True
-    ) as patched_idasen_desk:
+    with (
+        mock.patch(
+            "idasen_ha.connection_manager.IdasenDesk", autospec=True
+        ) as patched_idasen_desk,
+        mock.patch(
+            "idasen_ha.connection_manager.establish_connection"
+        ) as mock_establish_connection,
+    ):
         patched_idasen_desk.MIN_HEIGHT = IdasenDesk.MIN_HEIGHT
         patched_idasen_desk.MAX_HEIGHT = IdasenDesk.MAX_HEIGHT
 
@@ -25,29 +29,35 @@ async def mock_idasen_desk():
         def mock_init(
             mac_bledevice,
             exit_on_fail: bool = False,
-            disconnected_callback: Optional[Callable[[BleakClient], None]] = None,
+            disconnected_callback=None,
         ):
-            mock_desk.trigger_disconnected_callback = disconnected_callback
             return mock_desk
 
         patched_idasen_desk.side_effect = mock_init
 
-        async def mock_client_connect():
+        async def mock_establish_conn(
+            client_class, ble_device, address, disconnected_callback=None, **kwargs
+        ):
             mock_desk.is_connected = True
+            mock_desk.trigger_disconnected_callback = disconnected_callback
+            return MagicMock()
+
+        mock_establish_connection.side_effect = mock_establish_conn
 
         async def mock_disconnect():
             mock_desk.is_connected = False
-            mock_desk.trigger_disconnected_callback(None)
+            if mock_desk.trigger_disconnected_callback:
+                mock_desk.trigger_disconnected_callback(None)
 
         async def mock_monitor(callback: Callable[[float], Awaitable[None]]) -> None:
             mock_desk.trigger_monitor_callback = callback
 
-        mock_desk._client = AsyncMock()
-        mock_desk._client.connect = AsyncMock(side_effect=mock_client_connect)
+        mock_desk.connect = mock_establish_connection
         mock_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
         mock_desk.wakeup = AsyncMock()
         mock_desk.monitor = AsyncMock(side_effect=mock_monitor)
         mock_desk.is_connected = False
         mock_desk.is_moving = False
+        mock_desk.trigger_disconnected_callback = None
 
         yield mock_desk

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -274,6 +274,23 @@ async def test_connect_exception_retry_success(
     assert mock_idasen_desk.connect.call_count == TEST_RETRIES_MAX + 2
 
 
+async def test_connect_with_different_ble_device_address(mock_idasen_desk: MagicMock):
+    """Test that connect refreshes the desk when the BLE device address changes."""
+    update_callback = Mock()
+    desk = Desk(update_callback, False)
+
+    await desk.connect(FAKE_BLE_DEVICE)
+    assert desk.is_connected
+    assert update_callback.call_count == 1
+
+    await desk.disconnect()
+
+    new_device = BLEDevice("11:22:33:44:55:66", None, {"path": ""})
+    await desk.connect(new_device)
+    assert desk.is_connected
+    assert update_callback.call_count == 3
+
+
 async def test_reconnect_on_connection_drop(mock_idasen_desk: MagicMock):
     """Test reconnection when the connection drops."""
     update_callback = Mock()

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -21,7 +21,7 @@ async def test_connect_disconnect(mock_idasen_desk: MagicMock):
 
     await desk.connect(FAKE_BLE_DEVICE)
     assert desk.is_connected
-    mock_idasen_desk._client.connect.assert_awaited()
+    mock_idasen_desk.connect.assert_awaited()
     mock_idasen_desk.pair.assert_called()
     mock_idasen_desk.wakeup.assert_awaited_once()
     assert update_callback.call_count == 1
@@ -41,7 +41,7 @@ async def test_connect_skipped_when_already_connected(mock_idasen_desk: MagicMoc
     mock_idasen_desk.is_connected = True
 
     await desk.connect(FAKE_BLE_DEVICE)
-    mock_idasen_desk._client.connect.assert_not_awaited()
+    mock_idasen_desk.connect.assert_not_awaited()
     mock_idasen_desk.pair.assert_not_called()
     mock_idasen_desk.wakeup.assert_not_called()
     assert update_callback.call_count == 0
@@ -52,18 +52,18 @@ async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMo
     update_callback = Mock()
     desk = Desk(update_callback, False)
 
-    default_connect_side_effect = mock_idasen_desk._client.connect.side_effect
+    default_connect_side_effect = mock_idasen_desk.connect.side_effect
 
-    async def connect_side_effect():
+    async def connect_side_effect(*args, **kwargs):
         # call the seccond `connect` while the first is ongoing
         await desk.connect(FAKE_BLE_DEVICE)
-        await default_connect_side_effect()
+        await default_connect_side_effect(*args, **kwargs)
 
-    mock_idasen_desk._client.connect.side_effect = connect_side_effect
+    mock_idasen_desk.connect.side_effect = connect_side_effect
 
     await desk.connect(FAKE_BLE_DEVICE)
     assert desk.is_connected
-    mock_idasen_desk._client.connect.assert_awaited()
+    mock_idasen_desk.connect.assert_awaited()
     mock_idasen_desk.pair.assert_called()
     mock_idasen_desk.wakeup.assert_awaited_once()
     assert update_callback.call_count == 1
@@ -72,28 +72,45 @@ async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMo
 async def test_double_connect_call_with_different_bledevice():
     """Test connect being called again with a new BLEDevice, while still connecting."""
 
-    with mock.patch(
-        "idasen_ha.connection_manager.IdasenDesk", autospec=True
-    ) as patched_idasen_desk:
+    with (
+        mock.patch(
+            "idasen_ha.connection_manager.IdasenDesk", autospec=True
+        ) as patched_idasen_desk,
+        mock.patch(
+            "idasen_ha.connection_manager.establish_connection"
+        ) as mock_establish_connection,
+    ):
         mock_idasen_desk = patched_idasen_desk.return_value
+        mock_idasen_desk.is_connected = False
+        mock_idasen_desk.wakeup = AsyncMock()
 
-        async def connect_side_effect():
-            # call the seccond `connect` while the first is ongoing
-            mock_idasen_desk._client.connect.side_effect = MagicMock()
+        async def mock_disconnect():
+            mock_idasen_desk.is_connected = False
+
+        mock_idasen_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
+
+        async def first_establish_side_effect(
+            client_class, ble_device, address, **kwargs
+        ):
+            async def subsequent_establish(*args, **kw):
+                mock_idasen_desk.is_connected = True
+                return MagicMock()
+
+            mock_establish_connection.side_effect = subsequent_establish
             new_ble_device = BLEDevice("AA:BB:CC:DD:EE:AA", None, None)
             await desk.connect(new_ble_device)
+            mock_idasen_desk.is_connected = True
+            return MagicMock()
 
-        mock_idasen_desk.is_connected = False
-        mock_idasen_desk._client = AsyncMock()
-        mock_idasen_desk._client.connect.side_effect = connect_side_effect
-        mock_idasen_desk.wakeup = AsyncMock()
+        mock_establish_connection.side_effect = first_establish_side_effect
 
         update_callback = Mock()
         desk = Desk(update_callback, False)
         await desk.connect(FAKE_BLE_DEVICE)
 
-        mock_idasen_desk._client.connect.assert_awaited()
+        mock_establish_connection.assert_awaited()
         mock_idasen_desk.pair.assert_called()
+        assert mock_idasen_desk.wakeup.await_count == 2
         assert update_callback.call_count == 2
         assert patched_idasen_desk.call_count == 2
 
@@ -108,22 +125,22 @@ async def test_connect_called_while_retry_pending(
     update_callback = Mock()
     desk = Desk(update_callback, False)
 
-    default_connect_side_effect = mock_idasen_desk._client.connect.side_effect
+    default_connect_side_effect = mock_idasen_desk.connect.side_effect
 
     async def sleep_side_effect(delay):
-        mock_idasen_desk._client.connect.side_effect = default_connect_side_effect
+        mock_idasen_desk.connect.side_effect = default_connect_side_effect
         await desk.connect(FAKE_BLE_DEVICE)
         retry_maxed_future.set_result(None)
 
     sleep_mock.side_effect = sleep_side_effect
 
-    mock_idasen_desk._client.connect.side_effect = TimeoutError()
+    mock_idasen_desk.connect.side_effect = TimeoutError()
     await desk.connect(FAKE_BLE_DEVICE)
     assert not desk.is_connected
 
     await retry_maxed_future
     assert desk.is_connected
-    assert mock_idasen_desk._client.connect.call_count == 2
+    assert mock_idasen_desk.connect.call_count == 2
     assert update_callback.call_count == 1
 
 
@@ -131,7 +148,7 @@ async def test_connect_raises_without_auto_reconnect(mock_idasen_desk: MagicMock
     """Test that connect raises if auto_reconnect is False."""
     desk = Desk(Mock(), False)
 
-    mock_idasen_desk._client.connect.side_effect = TimeoutError()
+    mock_idasen_desk.connect.side_effect = TimeoutError()
     with pytest.raises(TimeoutError):
         await desk.connect(FAKE_BLE_DEVICE, retry=False)
     assert not desk.is_connected
@@ -185,7 +202,7 @@ async def test_disconnect_on_wakeup_failure(mock_idasen_desk: MagicMock):
 
 @mock.patch("idasen_ha.connection_manager.asyncio.sleep")
 @pytest.mark.parametrize("exception", [TimeoutError(), BleakError()])
-@pytest.mark.parametrize("fail_call_name", ["_client.connect", "pair", "wakeup"])
+@pytest.mark.parametrize("fail_call_name", ["connect", "pair", "wakeup"])
 async def test_connect_exception_retry_with_disconnect(
     sleep_mock,
     mock_idasen_desk: MagicMock,
@@ -208,14 +225,11 @@ async def test_connect_exception_retry_with_disconnect(
 
     desk = Desk(Mock(), False)
 
-    fail_target = mock_idasen_desk
-    for attr in fail_call_name.split("."):
-        fail_target = getattr(fail_target, attr)
-    fail_target.side_effect = exception
+    getattr(mock_idasen_desk, fail_call_name).side_effect = exception
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
-    assert mock_idasen_desk._client.connect.call_count == TEST_RETRIES_MAX + 1
+    assert mock_idasen_desk.connect.call_count == TEST_RETRIES_MAX + 1
 
 
 @mock.patch("idasen_ha.connection_manager.asyncio.sleep")
@@ -228,7 +242,7 @@ async def test_connect_exception_retry_with_disconnect(
         BleakDBusError("org.bluez.Error.AuthenticationFailed", []),
     ],
 )
-@pytest.mark.parametrize("fail_call_name", ["_client.connect", "pair", "wakeup"])
+@pytest.mark.parametrize("fail_call_name", ["connect", "pair", "wakeup"])
 async def test_connect_exception_retry_success(
     sleep_mock,
     mock_idasen_desk: MagicMock,
@@ -240,26 +254,24 @@ async def test_connect_exception_retry_success(
     retry_count = 0
     retry_maxed_future = asyncio.Future()
 
-    fail_target = mock_idasen_desk
-    for attr in fail_call_name.split("."):
-        fail_target = getattr(fail_target, attr)
-    default_fail_call_side_effect = fail_target.side_effect
+    fail_call = getattr(mock_idasen_desk, fail_call_name)
+    default_fail_call_side_effect = fail_call.side_effect
 
     async def sleep_handler(delay):
         nonlocal retry_count
         if retry_count == TEST_RETRIES_MAX:
-            fail_target.side_effect = default_fail_call_side_effect
+            fail_call.side_effect = default_fail_call_side_effect
             retry_maxed_future.set_result(None)
         retry_count = retry_count + 1
 
     sleep_mock.side_effect = sleep_handler
 
     desk = Desk(Mock(), False)
-    fail_target.side_effect = exception
+    fail_call.side_effect = exception
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
-    assert mock_idasen_desk._client.connect.call_count == TEST_RETRIES_MAX + 2
+    assert mock_idasen_desk.connect.call_count == TEST_RETRIES_MAX + 2
 
 
 async def test_reconnect_on_connection_drop(mock_idasen_desk: MagicMock):
@@ -272,13 +284,12 @@ async def test_reconnect_on_connection_drop(mock_idasen_desk: MagicMock):
     assert update_callback.call_count == 1
 
     mock_idasen_desk.reset_mock()
-    mock_idasen_desk._client.connect.reset_mock()
     await mock_idasen_desk.disconnect()
     assert not desk.is_connected
     assert update_callback.call_count == 2
 
     await asyncio.sleep(0)
     assert desk.is_connected
-    mock_idasen_desk._client.connect.assert_awaited()
+    mock_idasen_desk.connect.assert_awaited()
     mock_idasen_desk.pair.assert_called()
     assert update_callback.call_count == 3

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -74,7 +74,7 @@ async def test_double_connect_call_with_different_bledevice():
 
     with (
         mock.patch(
-            "idasen_ha.connection_manager.IdasenDesk", autospec=True
+            "idasen_ha.connection_manager.ManagedIdasenDesk", autospec=True
         ) as patched_idasen_desk,
         mock.patch(
             "idasen_ha.connection_manager.establish_connection"

--- a/tests/test_desk.py
+++ b/tests/test_desk.py
@@ -1,0 +1,36 @@
+"""Tests for ManagedIdasenDesk."""
+
+from unittest.mock import MagicMock
+
+from bleak.backends.device import BLEDevice
+
+from idasen_ha.desk import ManagedIdasenDesk
+
+
+def test_init_with_ble_device():
+    """Test that __init__ does not create a BleakClient."""
+    ble_device = BLEDevice("AA:BB:CC:DD:EE:FF", None, {"path": ""})
+    desk = ManagedIdasenDesk(ble_device, exit_on_fail=False)
+
+    assert desk.mac == "AA:BB:CC:DD:EE:FF"
+    assert desk._client is None
+    assert not desk._moving
+    assert desk._move_task is None
+
+
+def test_init_with_mac_string():
+    """Test init with a plain MAC address string."""
+    desk = ManagedIdasenDesk("AA:BB:CC:DD:EE:FF", exit_on_fail=False)
+
+    assert desk.mac == "AA:BB:CC:DD:EE:FF"
+    assert desk._client is None
+
+
+def test_set_client():
+    """Test that set_client replaces the internal client."""
+    desk = ManagedIdasenDesk("AA:BB:CC:DD:EE:FF")
+    assert desk._client is None
+
+    mock_client = MagicMock()
+    desk.set_client(mock_client)
+    assert desk._client is mock_client

--- a/tests/test_desk_functions.py
+++ b/tests/test_desk_functions.py
@@ -20,7 +20,7 @@ async def test_monitor_height(mock_idasen_desk: MagicMock):
     mock_idasen_desk.get_height.return_value = HEIGHT_MTS_1
 
     await desk.connect(FAKE_BLE_DEVICE)
-    mock_idasen_desk._client.connect.assert_called()
+    mock_idasen_desk.connect.assert_called()
     mock_idasen_desk.pair.assert_called()
     mock_idasen_desk.get_height.assert_called()
     update_callback.assert_called_with(HEIGHT_PCT_1)


### PR DESCRIPTION
## Summary

Replace the raw `BleakClient.connect()` path with `bleak_retry_connector.establish_connection()`, building on the wakeup ordering fix from #40.

- add `bleak-retry-connector` as a dependency
- use `establish_connection()` with `BleakClientWithServiceCache` for proper connection caching
- introduce `ManagedIdasenDesk` subclass to avoid creating an unused `BleakClient` in `__init__` and cleanly adopt the externally-established client
- accept the current `BLEDevice` in `ConnectionManager.connect()` so device-swap and reconnect paths stay aligned

## Why

With #40 merged, the wakeup ordering issue is resolved. This PR adds `bleak-retry-connector` which additionally:
- removes the `BleakClient.connect() called without bleak-retry-connector` HA warning
- enables `BleakClientWithServiceCache` so the ESPHome proxy can skip service discovery on reconnect (`Connecting v3 with cache`)
- provides a foundation for replacing the manual retry logic in a future PR, as discussed in #39

## Validation

- verified locally against Home Assistant + ESPHome Bluetooth proxy
- confirmed the `BleakClient.connect() called without bleak-retry-connector` warning is gone
- confirmed the desk reconnects with ESPHome proxy logs showing `Connecting v3 with cache`
- 44 tests pass, coverage at 97%

Related to home-assistant/core#155912.