### PR TITLE
feat: use bleak-retry-connector for BLE proxy connections

### DIFF
--- a/idasen_ha/__init__.py
+++ b/idasen_ha/__init__.py
@@ -51,7 +51,7 @@ class Desk:
             self._ble_device = ble_device
             self._connection_manager = self._create_connection_manager(self._ble_device)
 
-        await self._connection_manager.connect(retry)
+        await self._connection_manager.connect(ble_device, retry)
 
     async def disconnect(self) -> None:
         """Disconnect from the desk."""

--- a/idasen_ha/__init__.py
+++ b/idasen_ha/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import logging
-from typing import Callable
 
 from bleak.backends.device import BLEDevice
 from idasen import IdasenDesk

--- a/idasen_ha/__init__.py
+++ b/idasen_ha/__init__.py
@@ -51,7 +51,7 @@ class Desk:
             self._ble_device = ble_device
             self._connection_manager = self._create_connection_manager(self._ble_device)
 
-        await self._connection_manager.connect(ble_device, retry)
+        await self._connection_manager.connect(retry)
 
     async def disconnect(self) -> None:
         """Disconnect from the desk."""

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -1,9 +1,8 @@
 """Manages the connection state to the desk."""
 
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 import logging
-from typing import Callable, Optional
 
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
@@ -34,13 +33,13 @@ class ConnectionManager:
         self._retry_pending: bool = False
         self._ble_device = ble_device
 
-        self._idasen_desk: Optional[IdasenDesk] = None
+        self._idasen_desk: IdasenDesk | None = None
 
         self._connect_callback = connect_callback
         self._disconnect_callback = disconnect_callback
 
     @property
-    def idasen_desk(self) -> Optional[IdasenDesk]:
+    def idasen_desk(self) -> IdasenDesk | None:
         """The IdasenDesk instance, or None if not yet connected."""
         return self._idasen_desk
 

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -3,10 +3,15 @@
 import asyncio
 from collections.abc import Awaitable
 import logging
-from typing import Callable
+from typing import Callable, Optional
 
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakDBusError, BleakError
+from bleak_retry_connector import (
+    BleakClientWithServiceCache,
+    close_stale_connections_by_address,
+    establish_connection,
+)
 from idasen import IdasenDesk
 
 from .errors import AuthFailedError
@@ -27,37 +32,37 @@ class ConnectionManager:
         self._keep_connected: bool = False
         self._connecting: bool = False
         self._retry_pending: bool = False
+        self._ble_device = ble_device
 
-        self._idasen_desk: IdasenDesk = self._create_idasen_desk(ble_device)
+        self._idasen_desk: Optional[IdasenDesk] = None
 
         self._connect_callback = connect_callback
         self._disconnect_callback = disconnect_callback
 
     @property
-    def idasen_desk(self) -> IdasenDesk:
-        """The IdasenDesk instance."""
+    def idasen_desk(self) -> Optional[IdasenDesk]:
+        """The IdasenDesk instance, or None if not yet connected."""
         return self._idasen_desk
 
-    async def connect(self, retry: bool) -> None:
+    async def connect(self, ble_device: BLEDevice, retry: bool) -> None:
         """Perform the bluetooth connection to the desk."""
+        if ble_device.address != self._ble_device.address:
+            self._ble_device = ble_device
+            self._idasen_desk = None
         self._keep_connected = True
         await self._connect(retry)
 
     async def disconnect(self):
         """Stop the connection manager retry task."""
         self._keep_connected = False
-        if self._idasen_desk.is_connected:
+        if self._idasen_desk is not None and self._idasen_desk.is_connected:
             await self._idasen_desk.disconnect()
 
-    def _create_idasen_desk(self, ble_device: BLEDevice) -> IdasenDesk:
-        return IdasenDesk(
-            ble_device,
-            exit_on_fail=False,
-            disconnected_callback=lambda bledevice: self._handle_disconnect(),
-        )
+    def _create_idasen_desk(self, client: BleakClientWithServiceCache) -> IdasenDesk:
+        return IdasenDesk(self._ble_device, exit_on_fail=False, client=client)
 
     async def _connect(self, retry: bool) -> None:
-        if self._idasen_desk.is_connected:
+        if self._idasen_desk is not None and self._idasen_desk.is_connected:
             _LOGGER.debug("Desk already connected, skipping connect")
             return
 
@@ -68,10 +73,15 @@ class ConnectionManager:
         self._connecting = True
         try:
             try:
-                _LOGGER.info("Connecting...")
-                # Connect without wakeup — IdasenDesk.connect() bundles both,
-                # but we need pair() to complete before wakeup().
-                await self._idasen_desk._client.connect()  # noqa: SLF001
+                _LOGGER.info("Connecting via bleak-retry-connector...")
+                await close_stale_connections_by_address(self._ble_device.address)
+                client = await establish_connection(
+                    BleakClientWithServiceCache,
+                    self._ble_device,
+                    self._ble_device.address,
+                    disconnected_callback=lambda _client: self._handle_disconnect(),
+                )
+                self._idasen_desk = self._create_idasen_desk(client)
             except (TimeoutError, BleakError) as ex:
                 _LOGGER.exception("Connect failed")
                 if retry:
@@ -137,7 +147,7 @@ class ConnectionManager:
                 )
                 return
 
-            if self.idasen_desk.is_connected:
+            if self._idasen_desk is not None and self._idasen_desk.is_connected:
                 _LOGGER.debug("Already connected")
                 return
 
@@ -165,4 +175,4 @@ class ConnectionManager:
         self._disconnect_callback()
         if self._keep_connected and not self._retry_pending:
             _LOGGER.info("Reconnecting since it should not be disconnected")
-            asyncio.get_event_loop().create_task(self.connect(True))
+            asyncio.get_event_loop().create_task(self.connect(self._ble_device, True))

--- a/idasen_ha/connection_manager.py
+++ b/idasen_ha/connection_manager.py
@@ -44,11 +44,8 @@ class ConnectionManager:
         """The IdasenDesk instance, or None if not yet connected."""
         return self._idasen_desk
 
-    async def connect(self, ble_device: BLEDevice, retry: bool) -> None:
+    async def connect(self, retry: bool) -> None:
         """Perform the bluetooth connection to the desk."""
-        if ble_device.address != self._ble_device.address:
-            self._ble_device = ble_device
-            self._idasen_desk = None
         self._keep_connected = True
         await self._connect(retry)
 
@@ -57,9 +54,6 @@ class ConnectionManager:
         self._keep_connected = False
         if self._idasen_desk is not None and self._idasen_desk.is_connected:
             await self._idasen_desk.disconnect()
-
-    def _create_idasen_desk(self, client: BleakClientWithServiceCache) -> IdasenDesk:
-        return IdasenDesk(self._ble_device, exit_on_fail=False, client=client)
 
     async def _connect(self, retry: bool) -> None:
         if self._idasen_desk is not None and self._idasen_desk.is_connected:
@@ -81,7 +75,9 @@ class ConnectionManager:
                     self._ble_device.address,
                     disconnected_callback=lambda _client: self._handle_disconnect(),
                 )
-                self._idasen_desk = self._create_idasen_desk(client)
+                self._idasen_desk = IdasenDesk(
+                    self._ble_device, exit_on_fail=False, client=client
+                )
             except (TimeoutError, BleakError) as ex:
                 _LOGGER.exception("Connect failed")
                 if retry:
@@ -175,4 +171,4 @@ class ConnectionManager:
         self._disconnect_callback()
         if self._keep_connected and not self._retry_pending:
             _LOGGER.info("Reconnecting since it should not be disconnected")
-            asyncio.get_event_loop().create_task(self.connect(self._ble_device, True))
+            asyncio.get_event_loop().create_task(self.connect(True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "idasen>=0.10,<=0.12.0"
+    "idasen>=0.13.1,<0.14",
+    "bleak-retry-connector>=3.4.0",
 ]
 
 [project.readme]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "idasen>=0.13.1,<0.14",
     "bleak-retry-connector>=3.4.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-idasen>=0.10,<=0.12.0
+idasen>=0.13.1,<0.14
+bleak-retry-connector>=3.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,10 @@
 """Generic test fixtures."""
 
 from collections.abc import Awaitable
-from typing import Callable, Optional
+from typing import Callable
 from unittest import mock
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
-from bleak import BleakClient
 from idasen import IdasenDesk
 import pytest
 
@@ -14,9 +13,14 @@ import pytest
 async def mock_idasen_desk():
     """Test height monitoring."""
 
-    with mock.patch(
-        "idasen_ha.connection_manager.IdasenDesk", autospec=True
-    ) as patched_idasen_desk:
+    with (
+        mock.patch(
+            "idasen_ha.connection_manager.IdasenDesk", autospec=True
+        ) as patched_idasen_desk,
+        mock.patch(
+            "idasen_ha.connection_manager.establish_connection"
+        ) as mock_establish_connection,
+    ):
         patched_idasen_desk.MIN_HEIGHT = IdasenDesk.MIN_HEIGHT
         patched_idasen_desk.MAX_HEIGHT = IdasenDesk.MAX_HEIGHT
 
@@ -25,29 +29,36 @@ async def mock_idasen_desk():
         def mock_init(
             mac_bledevice,
             exit_on_fail: bool = False,
-            disconnected_callback: Optional[Callable[[BleakClient], None]] = None,
+            disconnected_callback=None,
+            client=None,
         ):
-            mock_desk.trigger_disconnected_callback = disconnected_callback
+            mock_desk.is_connected = client is not None
             return mock_desk
 
         patched_idasen_desk.side_effect = mock_init
 
-        async def mock_client_connect():
-            mock_desk.is_connected = True
+        async def mock_establish_conn(
+            client_class, ble_device, address, disconnected_callback=None, **kwargs
+        ):
+            mock_desk.trigger_disconnected_callback = disconnected_callback
+            return MagicMock()
+
+        mock_establish_connection.side_effect = mock_establish_conn
 
         async def mock_disconnect():
             mock_desk.is_connected = False
-            mock_desk.trigger_disconnected_callback(None)
+            if mock_desk.trigger_disconnected_callback:
+                mock_desk.trigger_disconnected_callback(None)
 
         async def mock_monitor(callback: Callable[[float], Awaitable[None]]) -> None:
             mock_desk.trigger_monitor_callback = callback
 
-        mock_desk._client = AsyncMock()
-        mock_desk._client.connect = AsyncMock(side_effect=mock_client_connect)
+        mock_desk.connect = mock_establish_connection
         mock_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
         mock_desk.wakeup = AsyncMock()
         mock_desk.monitor = AsyncMock(side_effect=mock_monitor)
         mock_desk.is_connected = False
         mock_desk.is_moving = False
+        mock_desk.trigger_disconnected_callback = None
 
         yield mock_desk

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 """Generic test fixtures."""
 
-from collections.abc import Awaitable
-from typing import Callable
+from collections.abc import Awaitable, Callable
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,12 +53,14 @@ async def mock_idasen_desk():
         async def mock_monitor(callback: Callable[[float], Awaitable[None]]) -> None:
             mock_desk.trigger_monitor_callback = callback
 
-        mock_desk.connect = mock_establish_connection
         mock_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
         mock_desk.wakeup = AsyncMock()
         mock_desk.monitor = AsyncMock(side_effect=mock_monitor)
         mock_desk.is_connected = False
         mock_desk.is_moving = False
         mock_desk.trigger_disconnected_callback = None
+        # Expose the establish_connection mock for tests that need to assert
+        # on or drive the connection attempt.
+        mock_desk.establish_connection = mock_establish_connection
 
         yield mock_desk

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -21,7 +21,7 @@ async def test_connect_disconnect(mock_idasen_desk: MagicMock):
 
     await desk.connect(FAKE_BLE_DEVICE)
     assert desk.is_connected
-    mock_idasen_desk.connect.assert_awaited()
+    mock_idasen_desk.establish_connection.assert_awaited()
     mock_idasen_desk.pair.assert_called()
     mock_idasen_desk.wakeup.assert_awaited_once()
     assert update_callback.call_count == 1
@@ -43,13 +43,13 @@ async def test_connect_skipped_when_already_connected(mock_idasen_desk: MagicMoc
     # callback invocations).
     await desk.connect(FAKE_BLE_DEVICE)
     assert desk.is_connected
-    initial_connect_count = mock_idasen_desk.connect.await_count
+    initial_connect_count = mock_idasen_desk.establish_connection.await_count
     initial_pair_count = mock_idasen_desk.pair.call_count
     initial_wakeup_count = mock_idasen_desk.wakeup.await_count
     initial_callback_count = update_callback.call_count
 
     await desk.connect(FAKE_BLE_DEVICE)
-    assert mock_idasen_desk.connect.await_count == initial_connect_count
+    assert mock_idasen_desk.establish_connection.await_count == initial_connect_count
     assert mock_idasen_desk.pair.call_count == initial_pair_count
     assert mock_idasen_desk.wakeup.await_count == initial_wakeup_count
     assert update_callback.call_count == initial_callback_count
@@ -60,18 +60,18 @@ async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMo
     update_callback = Mock()
     desk = Desk(update_callback, False)
 
-    default_connect_side_effect = mock_idasen_desk.connect.side_effect
+    default_connect_side_effect = mock_idasen_desk.establish_connection.side_effect
 
     async def connect_side_effect(*args, **kwargs):
         # call the seccond `connect` while the first is ongoing
         await desk.connect(FAKE_BLE_DEVICE)
         return await default_connect_side_effect(*args, **kwargs)
 
-    mock_idasen_desk.connect.side_effect = connect_side_effect
+    mock_idasen_desk.establish_connection.side_effect = connect_side_effect
 
     await desk.connect(FAKE_BLE_DEVICE)
     assert desk.is_connected
-    mock_idasen_desk.connect.assert_awaited()
+    mock_idasen_desk.establish_connection.assert_awaited()
     mock_idasen_desk.pair.assert_called()
     mock_idasen_desk.wakeup.assert_awaited_once()
     assert update_callback.call_count == 1
@@ -133,22 +133,22 @@ async def test_connect_called_while_retry_pending(
     update_callback = Mock()
     desk = Desk(update_callback, False)
 
-    default_connect_side_effect = mock_idasen_desk.connect.side_effect
+    default_connect_side_effect = mock_idasen_desk.establish_connection.side_effect
 
     async def sleep_side_effect(delay):
-        mock_idasen_desk.connect.side_effect = default_connect_side_effect
+        mock_idasen_desk.establish_connection.side_effect = default_connect_side_effect
         await desk.connect(FAKE_BLE_DEVICE)
         retry_maxed_future.set_result(None)
 
     sleep_mock.side_effect = sleep_side_effect
 
-    mock_idasen_desk.connect.side_effect = TimeoutError()
+    mock_idasen_desk.establish_connection.side_effect = TimeoutError()
     await desk.connect(FAKE_BLE_DEVICE)
     assert not desk.is_connected
 
     await retry_maxed_future
     assert desk.is_connected
-    assert mock_idasen_desk.connect.call_count == 2
+    assert mock_idasen_desk.establish_connection.call_count == 2
     assert update_callback.call_count == 1
 
 
@@ -156,7 +156,7 @@ async def test_connect_raises_without_auto_reconnect(mock_idasen_desk: MagicMock
     """Test that connect raises if auto_reconnect is False."""
     desk = Desk(Mock(), False)
 
-    mock_idasen_desk.connect.side_effect = TimeoutError()
+    mock_idasen_desk.establish_connection.side_effect = TimeoutError()
     with pytest.raises(TimeoutError):
         await desk.connect(FAKE_BLE_DEVICE, retry=False)
     assert not desk.is_connected
@@ -210,7 +210,7 @@ async def test_disconnect_on_wakeup_failure(mock_idasen_desk: MagicMock):
 
 @mock.patch("idasen_ha.connection_manager.asyncio.sleep")
 @pytest.mark.parametrize("exception", [TimeoutError(), BleakError()])
-@pytest.mark.parametrize("fail_call_name", ["connect", "pair", "wakeup"])
+@pytest.mark.parametrize("fail_call_name", ["establish_connection", "pair", "wakeup"])
 async def test_connect_exception_retry_with_disconnect(
     sleep_mock,
     mock_idasen_desk: MagicMock,
@@ -237,7 +237,7 @@ async def test_connect_exception_retry_with_disconnect(
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
-    assert mock_idasen_desk.connect.call_count == TEST_RETRIES_MAX + 1
+    assert mock_idasen_desk.establish_connection.call_count == TEST_RETRIES_MAX + 1
 
 
 @mock.patch("idasen_ha.connection_manager.asyncio.sleep")
@@ -250,7 +250,7 @@ async def test_connect_exception_retry_with_disconnect(
         BleakDBusError("org.bluez.Error.AuthenticationFailed", []),
     ],
 )
-@pytest.mark.parametrize("fail_call_name", ["connect", "pair", "wakeup"])
+@pytest.mark.parametrize("fail_call_name", ["establish_connection", "pair", "wakeup"])
 async def test_connect_exception_retry_success(
     sleep_mock,
     mock_idasen_desk: MagicMock,
@@ -279,7 +279,7 @@ async def test_connect_exception_retry_success(
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
-    assert mock_idasen_desk.connect.call_count == TEST_RETRIES_MAX + 2
+    assert mock_idasen_desk.establish_connection.call_count == TEST_RETRIES_MAX + 2
 
 
 async def test_connect_with_different_ble_device_address(mock_idasen_desk: MagicMock):
@@ -315,6 +315,6 @@ async def test_reconnect_on_connection_drop(mock_idasen_desk: MagicMock):
 
     await asyncio.sleep(0)
     assert desk.is_connected
-    mock_idasen_desk.connect.assert_awaited()
+    mock_idasen_desk.establish_connection.assert_awaited()
     mock_idasen_desk.pair.assert_called()
     assert update_callback.call_count == 3

--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -21,7 +21,7 @@ async def test_connect_disconnect(mock_idasen_desk: MagicMock):
 
     await desk.connect(FAKE_BLE_DEVICE)
     assert desk.is_connected
-    mock_idasen_desk._client.connect.assert_awaited()
+    mock_idasen_desk.connect.assert_awaited()
     mock_idasen_desk.pair.assert_called()
     mock_idasen_desk.wakeup.assert_awaited_once()
     assert update_callback.call_count == 1
@@ -38,13 +38,21 @@ async def test_connect_skipped_when_already_connected(mock_idasen_desk: MagicMoc
     update_callback = Mock()
     desk = Desk(update_callback, False)
 
-    mock_idasen_desk.is_connected = True
+    # First connect to populate the desk; then call connect again and verify
+    # the second call is a no-op (no additional connect / pair / wakeup /
+    # callback invocations).
+    await desk.connect(FAKE_BLE_DEVICE)
+    assert desk.is_connected
+    initial_connect_count = mock_idasen_desk.connect.await_count
+    initial_pair_count = mock_idasen_desk.pair.call_count
+    initial_wakeup_count = mock_idasen_desk.wakeup.await_count
+    initial_callback_count = update_callback.call_count
 
     await desk.connect(FAKE_BLE_DEVICE)
-    mock_idasen_desk._client.connect.assert_not_awaited()
-    mock_idasen_desk.pair.assert_not_called()
-    mock_idasen_desk.wakeup.assert_not_called()
-    assert update_callback.call_count == 0
+    assert mock_idasen_desk.connect.await_count == initial_connect_count
+    assert mock_idasen_desk.pair.call_count == initial_pair_count
+    assert mock_idasen_desk.wakeup.await_count == initial_wakeup_count
+    assert update_callback.call_count == initial_callback_count
 
 
 async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMock):
@@ -52,18 +60,18 @@ async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMo
     update_callback = Mock()
     desk = Desk(update_callback, False)
 
-    default_connect_side_effect = mock_idasen_desk._client.connect.side_effect
+    default_connect_side_effect = mock_idasen_desk.connect.side_effect
 
-    async def connect_side_effect():
+    async def connect_side_effect(*args, **kwargs):
         # call the seccond `connect` while the first is ongoing
         await desk.connect(FAKE_BLE_DEVICE)
-        await default_connect_side_effect()
+        return await default_connect_side_effect(*args, **kwargs)
 
-    mock_idasen_desk._client.connect.side_effect = connect_side_effect
+    mock_idasen_desk.connect.side_effect = connect_side_effect
 
     await desk.connect(FAKE_BLE_DEVICE)
     assert desk.is_connected
-    mock_idasen_desk._client.connect.assert_awaited()
+    mock_idasen_desk.connect.assert_awaited()
     mock_idasen_desk.pair.assert_called()
     mock_idasen_desk.wakeup.assert_awaited_once()
     assert update_callback.call_count == 1
@@ -72,28 +80,45 @@ async def test_double_connect_call_with_same_bledevice(mock_idasen_desk: MagicMo
 async def test_double_connect_call_with_different_bledevice():
     """Test connect being called again with a new BLEDevice, while still connecting."""
 
-    with mock.patch(
-        "idasen_ha.connection_manager.IdasenDesk", autospec=True
-    ) as patched_idasen_desk:
+    with (
+        mock.patch(
+            "idasen_ha.connection_manager.IdasenDesk", autospec=True
+        ) as patched_idasen_desk,
+        mock.patch(
+            "idasen_ha.connection_manager.establish_connection"
+        ) as mock_establish_connection,
+    ):
         mock_idasen_desk = patched_idasen_desk.return_value
+        mock_idasen_desk.is_connected = False
+        mock_idasen_desk.wakeup = AsyncMock()
 
-        async def connect_side_effect():
-            # call the seccond `connect` while the first is ongoing
-            mock_idasen_desk._client.connect.side_effect = MagicMock()
+        async def mock_disconnect():
+            mock_idasen_desk.is_connected = False
+
+        mock_idasen_desk.disconnect = AsyncMock(side_effect=mock_disconnect)
+
+        async def first_establish_side_effect(
+            client_class, ble_device, address, **kwargs
+        ):
+            async def subsequent_establish(*args, **kw):
+                mock_idasen_desk.is_connected = True
+                return MagicMock()
+
+            mock_establish_connection.side_effect = subsequent_establish
             new_ble_device = BLEDevice("AA:BB:CC:DD:EE:AA", None, None)
             await desk.connect(new_ble_device)
+            mock_idasen_desk.is_connected = True
+            return MagicMock()
 
-        mock_idasen_desk.is_connected = False
-        mock_idasen_desk._client = AsyncMock()
-        mock_idasen_desk._client.connect.side_effect = connect_side_effect
-        mock_idasen_desk.wakeup = AsyncMock()
+        mock_establish_connection.side_effect = first_establish_side_effect
 
         update_callback = Mock()
         desk = Desk(update_callback, False)
         await desk.connect(FAKE_BLE_DEVICE)
 
-        mock_idasen_desk._client.connect.assert_awaited()
+        mock_establish_connection.assert_awaited()
         mock_idasen_desk.pair.assert_called()
+        assert mock_idasen_desk.wakeup.await_count == 2
         assert update_callback.call_count == 2
         assert patched_idasen_desk.call_count == 2
 
@@ -108,22 +133,22 @@ async def test_connect_called_while_retry_pending(
     update_callback = Mock()
     desk = Desk(update_callback, False)
 
-    default_connect_side_effect = mock_idasen_desk._client.connect.side_effect
+    default_connect_side_effect = mock_idasen_desk.connect.side_effect
 
     async def sleep_side_effect(delay):
-        mock_idasen_desk._client.connect.side_effect = default_connect_side_effect
+        mock_idasen_desk.connect.side_effect = default_connect_side_effect
         await desk.connect(FAKE_BLE_DEVICE)
         retry_maxed_future.set_result(None)
 
     sleep_mock.side_effect = sleep_side_effect
 
-    mock_idasen_desk._client.connect.side_effect = TimeoutError()
+    mock_idasen_desk.connect.side_effect = TimeoutError()
     await desk.connect(FAKE_BLE_DEVICE)
     assert not desk.is_connected
 
     await retry_maxed_future
     assert desk.is_connected
-    assert mock_idasen_desk._client.connect.call_count == 2
+    assert mock_idasen_desk.connect.call_count == 2
     assert update_callback.call_count == 1
 
 
@@ -131,7 +156,7 @@ async def test_connect_raises_without_auto_reconnect(mock_idasen_desk: MagicMock
     """Test that connect raises if auto_reconnect is False."""
     desk = Desk(Mock(), False)
 
-    mock_idasen_desk._client.connect.side_effect = TimeoutError()
+    mock_idasen_desk.connect.side_effect = TimeoutError()
     with pytest.raises(TimeoutError):
         await desk.connect(FAKE_BLE_DEVICE, retry=False)
     assert not desk.is_connected
@@ -185,7 +210,7 @@ async def test_disconnect_on_wakeup_failure(mock_idasen_desk: MagicMock):
 
 @mock.patch("idasen_ha.connection_manager.asyncio.sleep")
 @pytest.mark.parametrize("exception", [TimeoutError(), BleakError()])
-@pytest.mark.parametrize("fail_call_name", ["_client.connect", "pair", "wakeup"])
+@pytest.mark.parametrize("fail_call_name", ["connect", "pair", "wakeup"])
 async def test_connect_exception_retry_with_disconnect(
     sleep_mock,
     mock_idasen_desk: MagicMock,
@@ -208,14 +233,11 @@ async def test_connect_exception_retry_with_disconnect(
 
     desk = Desk(Mock(), False)
 
-    fail_target = mock_idasen_desk
-    for attr in fail_call_name.split("."):
-        fail_target = getattr(fail_target, attr)
-    fail_target.side_effect = exception
+    getattr(mock_idasen_desk, fail_call_name).side_effect = exception
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
-    assert mock_idasen_desk._client.connect.call_count == TEST_RETRIES_MAX + 1
+    assert mock_idasen_desk.connect.call_count == TEST_RETRIES_MAX + 1
 
 
 @mock.patch("idasen_ha.connection_manager.asyncio.sleep")
@@ -228,7 +250,7 @@ async def test_connect_exception_retry_with_disconnect(
         BleakDBusError("org.bluez.Error.AuthenticationFailed", []),
     ],
 )
-@pytest.mark.parametrize("fail_call_name", ["_client.connect", "pair", "wakeup"])
+@pytest.mark.parametrize("fail_call_name", ["connect", "pair", "wakeup"])
 async def test_connect_exception_retry_success(
     sleep_mock,
     mock_idasen_desk: MagicMock,
@@ -240,26 +262,41 @@ async def test_connect_exception_retry_success(
     retry_count = 0
     retry_maxed_future = asyncio.Future()
 
-    fail_target = mock_idasen_desk
-    for attr in fail_call_name.split("."):
-        fail_target = getattr(fail_target, attr)
-    default_fail_call_side_effect = fail_target.side_effect
+    fail_call = getattr(mock_idasen_desk, fail_call_name)
+    default_fail_call_side_effect = fail_call.side_effect
 
     async def sleep_handler(delay):
         nonlocal retry_count
         if retry_count == TEST_RETRIES_MAX:
-            fail_target.side_effect = default_fail_call_side_effect
+            fail_call.side_effect = default_fail_call_side_effect
             retry_maxed_future.set_result(None)
         retry_count = retry_count + 1
 
     sleep_mock.side_effect = sleep_handler
 
     desk = Desk(Mock(), False)
-    fail_target.side_effect = exception
+    fail_call.side_effect = exception
     await desk.connect(FAKE_BLE_DEVICE)
 
     await retry_maxed_future
-    assert mock_idasen_desk._client.connect.call_count == TEST_RETRIES_MAX + 2
+    assert mock_idasen_desk.connect.call_count == TEST_RETRIES_MAX + 2
+
+
+async def test_connect_with_different_ble_device_address(mock_idasen_desk: MagicMock):
+    """Test that connect refreshes the desk when the BLE device address changes."""
+    update_callback = Mock()
+    desk = Desk(update_callback, False)
+
+    await desk.connect(FAKE_BLE_DEVICE)
+    assert desk.is_connected
+    assert update_callback.call_count == 1
+
+    await desk.disconnect()
+
+    new_device = BLEDevice("11:22:33:44:55:66", None, {"path": ""})
+    await desk.connect(new_device)
+    assert desk.is_connected
+    assert update_callback.call_count == 3
 
 
 async def test_reconnect_on_connection_drop(mock_idasen_desk: MagicMock):
@@ -272,13 +309,12 @@ async def test_reconnect_on_connection_drop(mock_idasen_desk: MagicMock):
     assert update_callback.call_count == 1
 
     mock_idasen_desk.reset_mock()
-    mock_idasen_desk._client.connect.reset_mock()
     await mock_idasen_desk.disconnect()
     assert not desk.is_connected
     assert update_callback.call_count == 2
 
     await asyncio.sleep(0)
     assert desk.is_connected
-    mock_idasen_desk._client.connect.assert_awaited()
+    mock_idasen_desk.connect.assert_awaited()
     mock_idasen_desk.pair.assert_called()
     assert update_callback.call_count == 3

--- a/tests/test_desk_functions.py
+++ b/tests/test_desk_functions.py
@@ -20,7 +20,7 @@ async def test_monitor_height(mock_idasen_desk: MagicMock):
     mock_idasen_desk.get_height.return_value = HEIGHT_MTS_1
 
     await desk.connect(FAKE_BLE_DEVICE)
-    mock_idasen_desk._client.connect.assert_called()
+    mock_idasen_desk.connect.assert_called()
     mock_idasen_desk.pair.assert_called()
     mock_idasen_desk.get_height.assert_called()
     update_callback.assert_called_with(HEIGHT_PCT_1)

--- a/tests/test_desk_functions.py
+++ b/tests/test_desk_functions.py
@@ -20,7 +20,7 @@ async def test_monitor_height(mock_idasen_desk: MagicMock):
     mock_idasen_desk.get_height.return_value = HEIGHT_MTS_1
 
     await desk.connect(FAKE_BLE_DEVICE)
-    mock_idasen_desk.connect.assert_called()
+    mock_idasen_desk.establish_connection.assert_called()
     mock_idasen_desk.pair.assert_called()
     mock_idasen_desk.get_height.assert_called()
     update_callback.assert_called_with(HEIGHT_PCT_1)


### PR DESCRIPTION
## Summary

Switch the BLE connection path to `bleak-retry-connector`'s `establish_connection()` for reliable connections through Bluetooth proxies, building on the wakeup-ordering fix from #40.

## Changes

- add `bleak-retry-connector` as a dependency
- use `establish_connection()` with `BleakClientWithServiceCache` for proper connection caching
- pass the pre-connected `BleakClient` to `IdasenDesk` via the new `client=` argument (added upstream in [newAM/idasen#492](https://github.com/newAM/idasen/pull/492)), avoiding the need for a downstream subclass
- store the connecting `BLEDevice` in `ConnectionManager` for the `bleak-retry-connector` connection path
- bump the `idasen` floor to `>=0.13.1,<0.14`
- bump `requires-python` to `>=3.10` (required by `idasen` 0.13.x)

## Why

The raw `BleakClient.connect()` path was unreliable through ESPHome Bluetooth proxies. `bleak-retry-connector` adds connection caching and retry/backoff that the HA Bluetooth stack already relies on elsewhere.

## Scope changes since the first revision

Per your review, this PR has been trimmed to the connection path only:

- The **move-loop fix** was upstreamed to `idasen` and released in 0.13.0 ([newAM/idasen#489](https://github.com/newAM/idasen/pull/489) - tolerant arrival detection). No move-loop code remains here.
- The **`ManagedIdasenDesk` subclass is gone**. Instead of subclassing to inject a client, `IdasenDesk` now accepts an optional `client=` argument ([newAM/idasen#492](https://github.com/newAM/idasen/pull/492), released in 0.13.1), so `ConnectionManager` just constructs `IdasenDesk(ble_device, client=client)` directly.

## Validation

- 37 tests pass
- `ruff` and `mypy` clean
- verified against Home Assistant + ESPHome Bluetooth proxy with a DPG1C controller